### PR TITLE
SlING-3343 Sling-Junit-Core Method Name in Test selctor is not honoured

### DIFF
--- a/testing/junit/core/src/main/java/org/apache/sling/junit/impl/servlet/JUnitServlet.java
+++ b/testing/junit/core/src/main/java/org/apache/sling/junit/impl/servlet/JUnitServlet.java
@@ -59,6 +59,8 @@ public class JUnitServlet extends HttpServlet {
     /** Non-null if we are registered with HttpService */ 
     private String servletPath;
     
+    private static final String EMPTY_STRING = "";
+    
     @Reference
     private TestsManager testsManager;
     
@@ -223,10 +225,13 @@ public class JUnitServlet extends HttpServlet {
     
     /** Return path to which to POST to execute specified test */
     protected String getTestExecutionPath(HttpServletRequest request, TestSelector selector, String extension) {
-        return request.getContextPath() 
-        + servletPath
-        + "/"
-        + selector.getTestSelectorString()
+    	String testExecutionPath = request.getContextPath() + servletPath
+    	        + "/"
+    	        + selector.getTestSelectorString();
+    	if (selector.getSelectedTestMethodName() != EMPTY_STRING) {
+    		testExecutionPath = testExecutionPath + "/" + selector.getSelectedTestMethodName();
+    	}
+        return testExecutionPath
         + "."
         + extension
         ;

--- a/testing/junit/core/src/main/java/org/apache/sling/junit/impl/servlet/SlingJUnitServlet.java
+++ b/testing/junit/core/src/main/java/org/apache/sling/junit/impl/servlet/SlingJUnitServlet.java
@@ -50,6 +50,8 @@ public class SlingJUnitServlet extends JUnitServlet {
     
     public static final String EXTENSION = ".junit";
     
+    private static final String EMPTY_STRING = "";
+    
     /** Do not register this servlet with HttpService ourselves,
      *  Sling will take care of that.
      */
@@ -72,8 +74,12 @@ public class SlingJUnitServlet extends JUnitServlet {
     
     /** Return path to which to POST to execute specified test */
     protected String getTestExecutionPath(HttpServletRequest request, TestSelector selector, String extension) {
-        return  "./"
-        + selector.getTestSelectorString()
+    	String testExecutionPath = "./"
+    	        + selector.getTestSelectorString();
+    	if (selector.getSelectedTestMethodName() != EMPTY_STRING) {
+    		testExecutionPath = testExecutionPath + "/" + selector.getSelectedTestMethodName();
+    	}
+        return testExecutionPath
         + "."
         + extension
         ;


### PR DESCRIPTION
Now method name is honoured while executing tests from browser.
Method name is added as part of test execution path i n junit and
slingjunit servlets which was not getting included.
