### PR TITLE
SLING-3443: Parameter based redirection vulnerability in FormAuthenticationHandler

### DIFF
--- a/bundles/auth/form/pom.xml
+++ b/bundles/auth/form/pom.xml
@@ -168,6 +168,24 @@
             <artifactId>jmock-junit4</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymock</artifactId>
+            <version>3.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>1.5.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-easymock</artifactId>
+            <version>1.5.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
         </dependency>

--- a/bundles/auth/form/src/main/java/org/apache/sling/auth/form/impl/FormAuthenticationHandler.java
+++ b/bundles/auth/form/src/main/java/org/apache/sling/auth/form/impl/FormAuthenticationHandler.java
@@ -25,7 +25,6 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Dictionary;
 import java.util.HashMap;
-
 import javax.jcr.Credentials;
 import javax.jcr.SimpleCredentials;
 import javax.servlet.Servlet;
@@ -477,10 +476,10 @@ public class FormAuthenticationHandler extends AbstractAuthenticationHandler {
             	result = false;
             } else {
             	// check whether redirect is requested by the resource parameter
-            	final String resource = getLoginResource(request, null);
+            	final String resource = AuthUtil.getLoginResource(request, null);
             	if (resource != null) {
             		try {
-            			response.sendRedirect(resource);
+                        AuthUtil.sendRedirect(request,response,resource,request.getParameterMap());
             		} catch (IOException ioe) {
             			log.error("Failed to send redirect to: " + resource, ioe);
             		}

--- a/bundles/auth/form/src/test/java/org/apache/sling/auth/form/FormReasonTest.java
+++ b/bundles/auth/form/src/test/java/org/apache/sling/auth/form/FormReasonTest.java
@@ -18,22 +18,26 @@
  */
 package org.apache.sling.auth.form;
 
-import org.apache.sling.auth.form.FormReason;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
-public class FormReasonTest extends TestCase {
+public class FormReasonTest {
 
+    @Test
     public void test_TIMEOUT() {
         assertEquals(FormReason.TIMEOUT,
             FormReason.valueOf(FormReason.TIMEOUT.name()));
     }
 
+    @Test
     public void test_INVALID_CREDENTIALS() {
         assertEquals(FormReason.INVALID_CREDENTIALS,
             FormReason.valueOf(FormReason.INVALID_CREDENTIALS.name()));
     }
 
+    @Test
     public void test_INVALID() {
         try {
             FormReason.valueOf("INVALID");


### PR DESCRIPTION
_FormAuthenticationHandler_ didn't url encode the parameter(_Authenticator.LOGIN_RESOURCE_) before redirection. This leads the attacker to use this parameter to redirect to a different domain. This may also help in phishing attacks. 

This was initially spotted in one of our applications which use org.apache.sling:org.apache.sling.auth.form:1.0.2

This pull request fixes the vulnerability (plus a testcase too).
