### PR TITLE
SLING-3510 Check for null classUrls and warn when no @Model classes found

### DIFF
--- a/bundles/extensions/models/impl/src/main/java/org/apache/sling/models/impl/ModelPackageBundleListener.java
+++ b/bundles/extensions/models/impl/src/main/java/org/apache/sling/models/impl/ModelPackageBundleListener.java
@@ -69,6 +69,12 @@ List<ServiceRegistration> regs = new ArrayList<ServiceRegistration>();
                 @SuppressWarnings("unchecked")
                 Enumeration<URL> classUrls = bundle.findEntries("/" + singlePackage.replace('.', '/'), "*.class",
                         true);
+
+                if (classUrls == null) {
+                    log.warn("No adaptable classes found in package {}, ignoring", singlePackage);
+                    continue;
+                }
+
                 while (classUrls.hasMoreElements()) {
                     URL url = classUrls.nextElement();
                     String className = toClassName(url);


### PR DESCRIPTION
When a non-existent package is added to Sling-Model-Packages, then an NPE is thrown as there are no matching classes found. I guess the same would happen for existing packages that contain no Model classes. Check for classUrls and warn, then continue if null.
