### PR TITLE
SLING-3776 JsonRendererServlet should provide a way to list children as ...

### DIFF
--- a/bundles/commons/json/src/main/java/org/apache/sling/commons/json/JSONObject.java
+++ b/bundles/commons/json/src/main/java/org/apache/sling/commons/json/JSONObject.java
@@ -1192,7 +1192,7 @@ public class JSONObject {
      *  with <code>}</code>&nbsp;<small>(right brace)</small>.
      * @throws JSONException If the object contains an invalid number.
      */
-     static String valueToString(Object value, int indentFactor, int indent)
+     public static String valueToString(Object value, int indentFactor, int indent)
             throws JSONException {
         if (value == null || value.equals(null)) {
             return "null";

--- a/bundles/servlets/get/src/main/java/org/apache/sling/servlets/get/impl/helpers/JsonRendererServlet.java
+++ b/bundles/servlets/get/src/main/java/org/apache/sling/servlets/get/impl/helpers/JsonRendererServlet.java
@@ -56,7 +56,7 @@ public class JsonRendererServlet extends SlingSafeMethodsServlet {
     public static final String TIDY = "tidy";
     public static final int TIDY_INDENTION = 2;
 
-    public static final String ARRAY = "array";
+    public static final String ARRAY = "harray";
 
     public static final String CHILDREN_KEY = "_children";
     public static final String CHILD_NAME_KEY = "_name";

--- a/launchpad/integration-tests/src/main/java/org/apache/sling/launchpad/webapp/integrationtest/JsonRenderingTest.java
+++ b/launchpad/integration-tests/src/main/java/org/apache/sling/launchpad/webapp/integrationtest/JsonRenderingTest.java
@@ -243,6 +243,45 @@ public class JsonRenderingTest extends HttpTestBase {
     	
     	assertTrue("The .tidy selector should add at least 5 EOL chars to json output (delta=" + delta + ")", delta > min);
     }
+
+    public void testHarrayNonRecursive() throws IOException {
+        // Count end-of-line chars, there must be the same amount if .harray is used
+        int noHarrayCount = countOccurences(getContent(createdNodeUrl + ".json", CONTENT_TYPE_JSON), '\n');
+        int HarrayCount = countOccurences(getContent(createdNodeUrl + ".harray.json", CONTENT_TYPE_JSON), '\n');
+
+        assertTrue("The .harray selector should have the same amount of EOL chars to json output (count=" + noHarrayCount + ")", HarrayCount == noHarrayCount);
+    }
+
+    public void testHarrayTidyNonRecursive() throws IOException {
+        // Count end-of-line chars, there must be more in the tidy form
+        int noHarrayTidyCount = countOccurences(getContent(createdNodeUrl + ".json", CONTENT_TYPE_JSON), '\n');
+        int HarrayTidyCount = countOccurences(getContent(createdNodeUrl + ".harray.tidy.json", CONTENT_TYPE_JSON), '\n');
+        int delta = HarrayTidyCount - noHarrayTidyCount;
+
+        // Output contains two properties so at least two EOL chars
+        int min = 2;
+
+        assertTrue("The .harray.tidy selector should add at least 2 EOL chars to json output (delta=" + delta + ")", delta > min);
+    }
+
+    public void testHarrayRootNoRecursion() throws IOException {
+        final String json = getContent(HTTP_BASE_URL + "/.harray.json", CONTENT_TYPE_JSON);
+
+        assertJavascript("undefined", json, "out.print(typeof data['_children'])");
+    }
+
+    public void testHarrayRootWithRecursion() throws IOException {
+        final String json = getContent(HTTP_BASE_URL + "/.harray.1.json", CONTENT_TYPE_JSON);
+
+        assertJavascript("[object Array]", json, "out.print(Object.prototype.toString.call(data['_children']))");
+    }
+
+    public void testHarrayRootNameWithRecursion() throws IOException {
+        // test if _name is existing in child node
+        final String json = getContent(HTTP_BASE_URL + "/.harray.1.json", CONTENT_TYPE_JSON);
+
+        assertJavascript("true", json, "out.print(data['_children'][0]._name.length > 0)");
+    }
     
     public void testRootNoRecursion() throws IOException {
     	final String json = getContent(HTTP_BASE_URL + "/.json", CONTENT_TYPE_JSON);


### PR DESCRIPTION
Adding an "array" selector will print the children of the node under the key "_children" and adds its key as a "_name" attribute. The wordings would need to be improved.

I did the implementation of it only in the servlet, some parts may be possible to be moved to JSONObject though imho I think it belongs rather to the servlet because it is for pure formatting.
