### PR TITLE
SLING-4079 - The LaunchpadConfigInstaller should skip over non-installable resources

### DIFF
--- a/launchpad/installer/src/main/java/org/apache/sling/launchpad/installer/impl/LaunchpadConfigInstaller.java
+++ b/launchpad/installer/src/main/java/org/apache/sling/launchpad/installer/impl/LaunchpadConfigInstaller.java
@@ -90,7 +90,7 @@ public class LaunchpadConfigInstaller {
 
                     final URL url = resourceProvider.getResource(path);
                     if(url == null){
-                    	throw new RuntimeException("Retrieved null resource for path: "+path);
+                        continue;
                     }
                     Dictionary<String, Object> dict = null;
                     if ( InstallableResource.TYPE_FILE.equals(resourceType) ) {


### PR DESCRIPTION
The attached commit skips over non-installable resources. All tests have run successfully after the change.
