### PR TITLE
SLING-4176 - Added validation/filtering for StyleToken context

### DIFF
--- a/contrib/scripting/sightly/engine/src/main/java/org/apache/sling/scripting/sightly/engine/extension/XSSRuntimeExtension.java
+++ b/contrib/scripting/sightly/engine/src/main/java/org/apache/sling/scripting/sightly/engine/extension/XSSRuntimeExtension.java
@@ -103,35 +103,29 @@ public class XSSRuntimeExtension extends RuntimeExtensionComponent {
             }
 
             private String applyXSSFilter(String text, MarkupContext xssContext) {
-                if (xssContext.equals(MarkupContext.ATTRIBUTE)) {
-                    return xssapi.encodeForHTMLAttr(text);
-                }
-                if (xssContext.equals(MarkupContext.COMMENT) ||
-                        xssContext.equals(MarkupContext.TEXT)) {
-                    return xssapi.encodeForHTML(text);
-                }
-                if (xssContext.equals(MarkupContext.ATTRIBUTE_NAME)) {
-                    return escapeAttributeName(text);
-                }
-                if (xssContext.equals(MarkupContext.NUMBER)) {
-                    return xssapi.getValidLong(text, 0).toString();
-                }
-                if (xssContext.equals(MarkupContext.URI)) {
-                    return xssapi.getValidHref(text);
-                }
-                if (xssContext.equals(MarkupContext.SCRIPT_TOKEN)
-                        || xssContext.equals(MarkupContext.SCRIPT_COMMENT)) {
-                    return xssapi.getValidJSToken(text, "");
-                }
-                if (xssContext.equals(MarkupContext.SCRIPT_STRING)
-                        || xssContext.equals(MarkupContext.STYLE_STRING)) {
-                    return xssapi.encodeForJSString(text);
-                }
-                if (xssContext.equals(MarkupContext.ELEMENT_NAME)) {
-                    return escapeElementName(text);
-                }
-                if (xssContext.equals(MarkupContext.HTML)) {
-                    return xssapi.filterHTML(text);
+                switch (xssContext) {
+                    case ATTRIBUTE:
+                        return xssapi.encodeForHTMLAttr(text);
+                    case COMMENT:
+                    case TEXT:
+                        return xssapi.encodeForHTML(text);
+                    case ATTRIBUTE_NAME:
+                        return escapeAttributeName(text);
+                    case NUMBER:
+                        return xssapi.getValidLong(text, 0).toString();
+                    case URI:
+                        return xssapi.getValidHref(text);
+                    case SCRIPT_TOKEN:
+                    case SCRIPT_COMMENT:
+                        return xssapi.getValidJSToken(text, "");
+                    case STYLE_TOKEN:
+                        return xssapi.getValidStyleToken(text, "");
+                    case SCRIPT_STRING:
+                        return xssapi.encodeForJSString(text);
+                    case ELEMENT_NAME:
+                        return escapeElementName(text);
+                    case HTML:
+                        return xssapi.filterHTML(text);
                 }
                 return text; //todo: apply the rest of XSS filters
             }

--- a/contrib/xss/src/main/java/org/apache/sling/xss/XSSAPI.java
+++ b/contrib/xss/src/main/java/org/apache/sling/xss/XSSAPI.java
@@ -86,6 +86,16 @@ public interface XSSAPI {
     public String getValidJSToken(String token, String defaultValue);
 
     /**
+     * Validate a style/CSS token. Valid CSS tokens are specified at http://www.w3.org/TR/css3-syntax/
+     *
+     * @param token        the source token
+     * @param defaultValue a default value to use if the source doesn't meet validity constraints.
+     *
+     * @return a string containing sanitized style token
+     */
+    public String getValidStyleToken(String token, String defaultValue);
+
+    /**
      * Validate a CSS color value. Color values as specified at http://www.w3.org/TR/css3-color/#colorunits
      * are safe and definitively allowed. Vulnerable constructs will be disallowed. Currently known
      * vulnerable constructs include url(...), expression(...), and anything with a semicolon.

--- a/contrib/xss/src/main/java/org/apache/sling/xss/impl/XSSAPIImpl.java
+++ b/contrib/xss/src/main/java/org/apache/sling/xss/impl/XSSAPIImpl.java
@@ -190,6 +190,46 @@ public class XSSAPIImpl implements XSSAPI {
         }
     }
 
+    private static final String NON_ASCII = "\\x00\\x08\\x0B\\x0C\\x0E-\\x1F";
+    /** http://www.w3.org/TR/css-syntax-3/#number-token-diagram */
+    private static final String NUMBER = "[+-]?[\\d]*[\\.]?[\\d]*(?:[e][+-]?\\d+)?";
+    /** http://www.w3.org/TR/css-syntax-3/#hex-digit-diagram */
+    private static final String HEX_DIGITS = "#[0-9a-f]*";
+    /** http://www.w3.org/TR/css-syntax-3/#ident-token-diagram */
+    private static final String IDENTIFIER = "-?[a-z_" + NON_ASCII + "][\\w_\\-" + NON_ASCII + "]*";
+    /** http://www.w3.org/TR/css-syntax-3/#string-token-diagram */
+    private static final String STRING = "\"(?:[^\"^\\\\^\\n]|(?:\\\\\"))*\"|'(?:[^'^\\\\^\\n]|(?:\\\\'))*'";
+    /** http://www.w3.org/TR/css-syntax-3/#dimension-token-diagram */
+    private static final String DIMENSION = NUMBER + IDENTIFIER;
+    /** http://www.w3.org/TR/css-syntax-3/#percentage-token-diagram */
+    private static final String PERCENT = NUMBER + "%";
+    /** http://www.w3.org/TR/css-syntax-3/#function-token-diagram */
+    private static final String FUNCTION = IDENTIFIER + "\\((?:(?:" + NUMBER + ")|(?:" + IDENTIFIER + ")|(?:[\\s]*)|(?:,))*\\)";
+    /** http://www.w3.org/TR/css-syntax-3/#url-unquoted-diagram */
+    private static final String URL_UNQUOTED = "[^\"^'^\\(^\\)^[" + NON_ASCII + "]]*";
+    /** http://www.w3.org/TR/css-syntax-3/#url-token-diagram */
+    private static final String URL = "url\\((?:(?:" + URL_UNQUOTED + ")|(?:" + STRING + "))\\)";
+    /** composite regular expression for style token validation */
+    private static final String CSS_TOKEN = "(?i)" // case insensitive
+            + "(?:" + NUMBER + ")"
+            + "|(?:" + DIMENSION + ")"
+            + "|(?:" + PERCENT + ")"
+            + "|(?:" + HEX_DIGITS + ")"
+            + "|(?:" + IDENTIFIER + ")"
+            + "|(?:" + STRING + ")"
+            + "|(?:" + FUNCTION + ")"
+            + "|(?:" + URL + ")";
+
+    /**
+     * @see org.apache.sling.xss.XSSAPI#getValidStyleToken(String, String)
+     */
+    public String getValidStyleToken(String token, String defaultValue) {
+        if (token.matches(CSS_TOKEN)) {
+            return token;
+        }
+        return defaultValue;
+    }
+
     /**
      * @see org.apache.sling.xss.XSSAPI#getValidCSSColor(String, String)
      */


### PR DESCRIPTION
Added validation/filtering for StyleToken context. Until now it was treated as unsafe, see: https://issues.apache.org/jira/browse/SLING-4176
