### PR TITLE
SLING-4167 - The Sightly implementation should provide support for escaped expressions

### DIFF
--- a/contrib/scripting/sightly/engine/src/main/antlr4/org/apache/sling/parser/expr/generated/SightlyLexer.g4
+++ b/contrib/scripting/sightly/engine/src/main/antlr4/org/apache/sling/parser/expr/generated/SightlyLexer.g4
@@ -18,6 +18,8 @@
  ******************************************************************************/
 lexer grammar SightlyLexer;
 
+ESC_EXPR: '\${'.*? '}';
+
 EXPR_START: '${' -> pushMode(ExpressionMode);
 
 TEXT_PART: .; //$hello ${expr}

--- a/contrib/scripting/sightly/engine/src/main/antlr4/org/apache/sling/parser/expr/generated/SightlyParser.g4
+++ b/contrib/scripting/sightly/engine/src/main/antlr4/org/apache/sling/parser/expr/generated/SightlyParser.g4
@@ -47,6 +47,8 @@ textFrag returns [String str]
 @init { StringBuilder sb = new StringBuilder(); }
     :   (TEXT_PART { sb.append($TEXT_PART.text); })+
         { $str = sb.toString(); }
+    | (ESC_EXPR { sb.append($ESC_EXPR.text); })+
+        { $str = sb.toString().substring(1); }
     ;
 
 expression returns [Expression expr]

--- a/contrib/scripting/sightly/testing-content/pom.xml
+++ b/contrib/scripting/sightly/testing-content/pom.xml
@@ -87,7 +87,7 @@
                                 <artifactItem>
                                     <groupId>io.sightly</groupId>
                                     <artifactId>io.sightly.tck</artifactId>
-                                    <version>1.0.1</version>
+                                    <version>1.0.2</version>
                                     <type>jar</type>
                                     <outputDirectory>${project.build.directory}/sightlytck/</outputDirectory>
                                     <includes>**/*.html,**/*.js,**/*.java</includes>

--- a/contrib/scripting/sightly/testing-content/src/main/resources/SLING-INF/sightlytck.json
+++ b/contrib/scripting/sightly/testing-content/src/main/resources/SLING-INF/sightlytck.json
@@ -21,6 +21,10 @@
         "xss" : {
             "jcr:primaryType": "nt:unstructured",
             "sling:resourceType": "/sightlytck/scripts/exprlang/xss"
+        },
+        "escapedexpr": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "/sightlytck/scripts/exprlang/escapedexpr"
         }
     },
     "blockstatements": {

--- a/contrib/scripting/sightly/testing/pom.xml
+++ b/contrib/scripting/sightly/testing/pom.xml
@@ -278,7 +278,7 @@
         <dependency>
             <groupId>io.sightly</groupId>
             <artifactId>io.sightly.tck</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.2</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
This commit adds the following changes:
- defined escaped expressions in the lexer
- defined escaped expressions as text fragments in the parser
- updated TCK version from Adobe to use the new escaped expressions tests
- added a resource for the new tests in the testing-content module
