### PR TITLE
SLING-4182 - Cleanup Sightly Engine dependencies

### DIFF
--- a/contrib/scripting/sightly/engine/pom.xml
+++ b/contrib/scripting/sightly/engine/pom.xml
@@ -253,7 +253,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.0</version>
+            <version>2.4</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/contrib/scripting/sightly/engine/pom.xml
+++ b/contrib/scripting/sightly/engine/pom.xml
@@ -170,7 +170,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.commons.osgi</artifactId>
-            <version>2.2.0</version>
+            <version>2.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -187,32 +187,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.scripting.javascript</artifactId>
-            <version>2.0.12</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.sling</groupId>
-                    <artifactId>org.apache.sling.jcr.resource</artifactId>
-                </exclusion>
-            </exclusions>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.jcr.api</artifactId>
-            <version>2.1.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.jcr.resource</artifactId>
-            <version>2.2.8</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.settings</artifactId>
-            <version>1.3.0</version>
+            <version>1.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -230,7 +206,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.commons.compiler</artifactId>
-            <version>2.1.0</version>
+            <version>2.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -257,7 +233,6 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
-            <version>2.5</version>
             <scope>provided</scope>
         </dependency>
 
@@ -278,7 +253,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
+            <version>2.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/contrib/scripting/sightly/engine/src/main/java/org/apache/sling/scripting/sightly/api/ResourceResolution.java
+++ b/contrib/scripting/sightly/engine/src/main/java/org/apache/sling/scripting/sightly/api/ResourceResolution.java
@@ -20,12 +20,10 @@
 package org.apache.sling.scripting.sightly.api;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.sling.api.SlingConstants;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceUtil;
-import org.apache.sling.jcr.resource.JcrResourceConstants;
 
 /**
  * Utility class which used by the Sightly engine & extensions


### PR DESCRIPTION
- reverted `commons-io` to 2.4 due to the incorrect metadata info from 2.0
