### PR TITLE
SLING-4327-added support for custom root paths for resource resolver

### DIFF
--- a/bundles/api/src/main/java/org/apache/sling/api/resource/ResourceResolverFactory.java
+++ b/bundles/api/src/main/java/org/apache/sling/api/resource/ResourceResolverFactory.java
@@ -129,6 +129,27 @@ public interface ResourceResolverFactory {
      * returned will only have administrative privileges if the user identified
      * by the property has administrative privileges.
      * <p>
+     * The {@link #USER_IMPERSONATION} property is obeyed but requires that the actual user has permission to
+     * impersonate as the requested user. If such permission is missing, a {@code LoginException} is thrown.
+     * 
+     * @param authenticationInfo A map of further credential information which may be used by the
+     * implementation to parameterize how the resource resolver is created. This may be <code>null</code>.
+     * @param customRootMap root map to the mapping configuration
+     * @return A {@link ResourceResolver} according to the <code>authenticationInfo</code>.
+     * @throws LoginException If an error occurs creating the new <code>ResourceResolver</code> with the
+     * provided credential data.
+     */
+    ResourceResolver getResourceResolver(Map<String, Object> authenticationInfo, String customRootMap)
+            throws LoginException;
+
+    /**
+     * Returns a new {@link ResourceResolver} instance with administrative privileges with further
+     * configuration taken from the given <code>authenticationInfo</code> map.
+     * <p>
+     * Note, that if the <code>authenticationInfo</code> map contains the {@link #USER_IMPERSONATION}
+     * attribute the <code>ResourceResolver</code> returned will only have administrative privileges if the
+     * user identified by the property has administrative privileges.
+     * <p>
      * <b><i>NOTE: This method is intended for use by infrastructure bundles to
      * access the repository and provide general services. This method MUST not
      * be used to handle client requests of whatever kinds. To handle client

--- a/bundles/resourceresolver/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverFactoryImpl.java
+++ b/bundles/resourceresolver/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverFactoryImpl.java
@@ -107,6 +107,16 @@ public class ResourceResolverFactoryImpl implements ResourceResolverFactory {
         return commonFactory.getAdministrativeResourceResolver(authenticationInfo);
     }
 
+    public ResourceResolver getResourceResolver(final Map<String, Object> authenticationInfo,
+            final String customPathRoot) throws LoginException {
+        return commonFactory.getResourceResolver(authenticationInfo, customPathRoot);
+    }
+
+    public ResourceResolver getAdministrativeResourceResolver(final Map<String, Object> authenticationInfo,
+            final String customPathRoot) throws LoginException {
+        return commonFactory.getAdministrativeResourceResolver(authenticationInfo, customPathRoot);
+    }
+
     /**
      * @see org.apache.sling.api.resource.ResourceResolverFactory#getThreadResourceResolver()
      */

--- a/bundles/resourceresolver/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverImpl.java
+++ b/bundles/resourceresolver/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverImpl.java
@@ -94,12 +94,19 @@ public class ResourceResolverImpl extends SlingAdaptable implements ResourceReso
     /** Resource resolver context. */
     private final ResourceResolverContext context;
 
+    private final String mapRoot;
+
     /**
      * The resource resolver context.
      */
-    public ResourceResolverImpl(final CommonResourceResolverFactoryImpl factory, final ResourceResolverContext ctx) {
+    public ResourceResolverImpl(final CommonResourceResolverFactoryImpl factory, String mapRoot, final ResourceResolverContext ctx) {
         this.factory = factory;
+        this.mapRoot = mapRoot;
         this.context = ctx;
+    }
+
+    public ResourceResolverImpl(final CommonResourceResolverFactoryImpl factory, final ResourceResolverContext ctx) {
+        this(factory, factory.getMapRoot(), ctx);
     }
 
     /**
@@ -125,7 +132,7 @@ public class ResourceResolverImpl extends SlingAdaptable implements ResourceReso
         this.factory.getRootProviderEntry().loginToRequiredFactories(newContext);
 
         // create a regular resource resolver
-        return new ResourceResolverImpl(this.factory, newContext);
+        return new ResourceResolverImpl(this.factory, mapRoot, newContext);
     }
 
     /**
@@ -494,7 +501,7 @@ public class ResourceResolverImpl extends SlingAdaptable implements ResourceReso
         }
 
         boolean mappedPathIsUrl = false;
-        for (final MapEntry mapEntry : this.factory.getMapEntries().getMapMaps()) {
+        for (final MapEntry mapEntry : this.factory.getMapEntries().getMapMaps(mapRoot)) {
             final String[] mappedPaths = mapEntry.replace(mappedPath);
             if (mappedPaths != null) {
 

--- a/bundles/resourceresolver/src/test/java/org/apache/sling/resourceresolver/impl/ResourceResolverMangleNamespacesTest.java
+++ b/bundles/resourceresolver/src/test/java/org/apache/sling/resourceresolver/impl/ResourceResolverMangleNamespacesTest.java
@@ -34,7 +34,10 @@ import org.mockito.MockitoAnnotations;
 
 /** Test ResourceResolverImpl.mangleNamespaces methods */
 public class ResourceResolverMangleNamespacesTest {
+
     private ResourceResolverImpl rr;
+
+    private static final String DEFAULT_MAPPING_LOCATION = "/etc/map";
 
     @Mock
     private Session mockedSession;
@@ -42,6 +45,7 @@ public class ResourceResolverMangleNamespacesTest {
     private Session activeSession;
 
     public static final String NS_PREFIX = "testNS";
+
     public static final String NS_URL = "http://example.com/namespaces/testNS";
 
     @Before
@@ -77,7 +81,8 @@ public class ResourceResolverMangleNamespacesTest {
             }
         };
 
-        rr = new ResourceResolverImpl(fac, new ResourceResolverContext(false, null, new ResourceAccessSecurityTracker()));
+        rr = new ResourceResolverImpl(fac, DEFAULT_MAPPING_LOCATION, new ResourceResolverContext(false, null,
+                new ResourceAccessSecurityTracker()));
     }
 
     @Test


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SLING-4327

ovide ability to create a ResourceResolver which is aware of any mappings, for example by providing proper argument mappingPath. In case of AEM it would be possible to use publish instance mapping present under etc/publish.map to on author instance.
To achieve that the CommonResourceResolverFactoryImpl could be implementing methods getResourceResolver() and getAdministrativeResourceResolver() with additional argument defining the mapping location. The advantage of this solution is that the created ResourceResolver can be used many times with the same mappings. The drawback is that the mappings configuration will be found and cached when they resourceresolver will be used for the first time - there is no possibility to define the list of working mappings before.
The proposal of API extension:

ResourceResolver getResourceResolver(Map<String, Object> authenticationInfo, String customRootMap) throws LoginException;

ResourceResolver getAdministrativeResourceResolver(Map<String, Object> authenticationInfo, String customRootMap) throws LoginException;
