### PR TITLE
SLING-4428 -  Sightly: scriptComment and styleComment contexts are not doing anything

### DIFF
--- a/contrib/extensions/xss/src/main/java/org/apache/sling/xss/XSSAPI.java
+++ b/contrib/extensions/xss/src/main/java/org/apache/sling/xss/XSSAPI.java
@@ -119,6 +119,16 @@ public interface XSSAPI {
     @Nullable
     public String getValidCSSColor(@Nullable String color, @Nullable String defaultColor);
 
+    /**
+     * Validate multiline comment to be used inside a <script>...</script> or <style>...</style> block. Multiline
+     * comment end block is disallowed
+     *
+     * @param comment           the comment to be used
+     * @param defaultComment    a default value to use if the comment is {@code null} or not valid.
+     * @return a valid multiline comment
+     */
+    public String getValidMultiLineComment(@Nullable String comment, @Nullable String defaultComment);
+
     // =============================================================================================
     // ENCODERS
     //

--- a/contrib/extensions/xss/src/main/java/org/apache/sling/xss/impl/XSSAPIImpl.java
+++ b/contrib/extensions/xss/src/main/java/org/apache/sling/xss/impl/XSSAPIImpl.java
@@ -265,6 +265,16 @@ public class XSSAPIImpl implements XSSAPI {
         return defaultColor;
     }
 
+    /**
+     * @see org.apache.sling.xss.XSSAPI#getValidMultiLineComment(String, String)
+     */
+    public String getValidMultiLineComment(String comment, String defaultComment) {
+        if (comment != null && !comment.contains("*/")) {
+            return comment;
+        }
+        return defaultComment;
+    }
+
     // =============================================================================================
     // ENCODERS
     //

--- a/contrib/extensions/xss/src/test/java/org/apache/sling/xss/impl/XSSAPIImplTest.java
+++ b/contrib/extensions/xss/src/test/java/org/apache/sling/xss/impl/XSSAPIImplTest.java
@@ -522,4 +522,25 @@ public class XSSAPIImplTest {
             }
         }
     }
+
+    @Test
+    public void TestGetValidMultiLineComment() {
+        String[][] testData = {
+                //Source            Expected Result
+
+                {null               , RUBBISH},
+                {"blah */ hack"     , RUBBISH},
+
+                {"Valid comment"    , "Valid comment"}
+        };
+        for (String[] aTestData : testData) {
+            String source = aTestData[0];
+            String expected = aTestData[1];
+
+            String result = xssAPI.getValidMultiLineComment(source, RUBBISH);
+            if (!result.equals(expected)) {
+                fail("Validating multiline comment '" + source + "', expecting '" + expected + "', but got '" + result + "'");
+            }
+        }
+    }
 }

--- a/contrib/scripting/sightly/engine/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/XSSRuntimeExtension.java
+++ b/contrib/scripting/sightly/engine/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/XSSRuntimeExtension.java
@@ -109,7 +109,6 @@ public class XSSRuntimeExtension implements RuntimeExtension {
             case URI:
                 return xssapi.getValidHref(text);
             case SCRIPT_TOKEN:
-            case SCRIPT_COMMENT:
                 return xssapi.getValidJSToken(text, "");
             case STYLE_TOKEN:
                 return xssapi.getValidStyleToken(text, "");
@@ -117,6 +116,9 @@ public class XSSRuntimeExtension implements RuntimeExtension {
                 return xssapi.encodeForJSString(text);
             case STYLE_STRING:
                 return xssapi.encodeForCSSString(text);
+            case SCRIPT_COMMENT:
+            case STYLE_COMMENT:
+                return xssapi.getValidMultiLineComment(text, "");
             case ELEMENT_NAME:
                 return escapeElementName(text);
             case HTML:

--- a/contrib/scripting/sightly/engine/src/main/java/org/apache/sling/scripting/sightly/impl/plugin/MarkupContext.java
+++ b/contrib/scripting/sightly/engine/src/main/java/org/apache/sling/scripting/sightly/impl/plugin/MarkupContext.java
@@ -38,6 +38,7 @@ public enum MarkupContext {
     SCRIPT_REGEXP("scriptRegExp"),
     STYLE_TOKEN("styleToken"),
     STYLE_STRING("styleString"),
+    STYLE_COMMENT("styleComment"),
     COMMENT("comment"),
     NUMBER("number"),
     UNSAFE("unsafe");


### PR DESCRIPTION
Added support for multiline comment validation in XSS API.
Added implementation and test.
Added styleComment context to Sightly.
Added proper validation for scriptComment and styleComment contexts.
