### PR TITLE
SLING-4484 - XSS POM references wrong scm URLs

### DIFF
--- a/contrib/extensions/xss/pom.xml
+++ b/contrib/extensions/xss/pom.xml
@@ -41,9 +41,9 @@
     </description>
 
     <scm>
-        <connection>scm:svn:http://svn.apache.org/repos/asf/sling/trunk/bundles/xss</connection>
-        <developerConnection>scm:svn:https://svn.apache.org/repos/asf/sling/trunk/bundles/xss</developerConnection>
-        <url>http://svn.apache.org/viewvc/sling/trunk/bundles/xss</url>
+        <connection>scm:svn:http://svn.apache.org/repos/asf/sling/trunk/contrib/extensions/xss</connection>
+        <developerConnection>scm:svn:https://svn.apache.org/repos/asf/sling/trunk/contrib/extensions/xss</developerConnection>
+        <url>http://svn.apache.org/viewvc/sling/trunk/contrib/extensions/xss</url>
     </scm>
 
     <!-- ======================================================================= -->


### PR DESCRIPTION
Updated URLs to point to correct location.
