### PR TITLE
SLING-4489 - Sightly: Hyphenated identifiers cause a compilation exception in Sightly generated Java classes

### DIFF
--- a/contrib/scripting/sightly/engine/src/main/java/org/apache/sling/scripting/sightly/impl/compiled/VariableAnalyzer.java
+++ b/contrib/scripting/sightly/engine/src/main/java/org/apache/sling/scripting/sightly/impl/compiled/VariableAnalyzer.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 
+import org.apache.sling.scripting.sightly.impl.compiler.SightlyParsingException;
 import org.apache.sling.scripting.sightly.impl.compiler.util.VariableTracker;
 
 /**
@@ -133,7 +134,7 @@ public class VariableAnalyzer {
     private VariableDescriptor dynamicDescriptor(String original) {
         VariableDescriptor descriptor = dynamicVariables.get(original);
         if (descriptor == null) {
-            String dynamicName = findDynamicName(original);
+            String dynamicName = findDynamicName(validName(original));
             descriptor = new VariableDescriptor(original, dynamicName, Type.UNKNOWN, VariableScope.DYNAMIC);
             dynamicVariables.put(original, descriptor);
             variables.add(descriptor);
@@ -142,7 +143,7 @@ public class VariableAnalyzer {
     }
 
     private String findDynamicName(String original) {
-        return DYNAMIC_PREFIX + original;
+        return DYNAMIC_PREFIX + syntaxSafeName(original);
     }
 
     private String findGlobalName(String original) {
@@ -164,6 +165,13 @@ public class VariableAnalyzer {
             return "_" + original;
         }
         return original.replaceAll("-", "_");
+    }
+
+    private String validName(String name) {
+        if (name == null || name.contains("-")) {
+            throw new SightlyParsingException("Unsupported identifier name: " + name);
+        }
+        return name.toLowerCase();
     }
 
     static {

--- a/contrib/scripting/sightly/testing-content/src/main/resources/SLING-INF/apps/sightly/scripts/template/bad-id.html
+++ b/contrib/scripting/sightly/testing-content/src/main/resources/SLING-INF/apps/sightly/scripts/template/bad-id.html
@@ -1,0 +1,1 @@
+<template data-sly-template.bad-template-id=" @ ">should produce parsing exception</template>

--- a/contrib/scripting/sightly/testing-content/src/main/resources/SLING-INF/apps/sightly/scripts/template/template.html
+++ b/contrib/scripting/sightly/testing-content/src/main/resources/SLING-INF/apps/sightly/scripts/template/template.html
@@ -1,0 +1,2 @@
+<template data-sly-template.templ=" @ ">SUCCESS</template>
+<div id="template" data-sly-call="${templ}"></div>

--- a/contrib/scripting/sightly/testing-content/src/main/resources/SLING-INF/sightly.json
+++ b/contrib/scripting/sightly/testing-content/src/main/resources/SLING-INF/sightly.json
@@ -12,5 +12,9 @@
     "includedresource": {
         "jcr:primaryType": "nt:unstructured",
         "sling:resourceType": "/apps/sightly/scripts/includedresource"
+    },
+    "template": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "/apps/sightly/scripts/template"
     }
 }

--- a/contrib/scripting/sightly/testing/src/test/java/org/apache/sling/scripting/sightly/it/SlingSpecificsSightlyIT.java
+++ b/contrib/scripting/sightly/testing/src/test/java/org/apache/sling/scripting/sightly/it/SlingSpecificsSightlyIT.java
@@ -34,6 +34,8 @@ public class SlingSpecificsSightlyIT {
     private static final String SLING_USE = "/sightly/use.html";
     private static final String SLING_JAVA_USE_NPE = "/sightly/use.javaerror.html";
     private static final String SLING_RESOURCE = "/sightly/resource.html";
+    private static final String SLING_TEMPLATE = "/sightly/template.html";
+    private static final String SLING_TEMPLATE_BAD_IDENTIFIER = "/sightly/template.bad-id.html";
 
     @BeforeClass
     public static void init() {
@@ -74,6 +76,20 @@ public class SlingSpecificsSightlyIT {
         assertEquals("selectors: a.c", HTMLExtractor.innerHTML(url, pageContent, "#removeselectors-remove-b span.selectors"));
         assertEquals("selectors: a.b.c", HTMLExtractor.innerHTML(url, pageContent, "#addselectors span.selectors"));
         assertEquals("It works", HTMLExtractor.innerHTML(url, pageContent, "#dot"));
+    }
+
+    @Test
+    public void testDataSlyTemplate() {
+        String url = launchpadURL + SLING_TEMPLATE;
+        String pageContent = client.getStringContent(url, 200);
+        assertEquals("SUCCESS", HTMLExtractor.innerHTML(url, pageContent, "#template"));
+    }
+
+    @Test
+    public void testBadTemplateIdentifier() {
+        String url = launchpadURL + SLING_TEMPLATE_BAD_IDENTIFIER;
+        String pageContent = client.getStringContent(url, 500);
+        assertTrue(pageContent.contains("org.apache.sling.scripting.sightly.impl.compiler.SightlyParsingException"));
     }
 
 }


### PR DESCRIPTION
Added hyphen checks and parsing exception throwing.
Added integration tests.
