### PR TITLE
SLING-4499 - Sightly: Parsing errors should not show up in console/stdout

### DIFF
--- a/contrib/scripting/sightly/engine/src/main/java/org/apache/sling/scripting/sightly/impl/compiler/frontend/ExpressionParser.java
+++ b/contrib/scripting/sightly/engine/src/main/java/org/apache/sling/scripting/sightly/impl/compiler/frontend/ExpressionParser.java
@@ -45,6 +45,8 @@ public class ExpressionParser {
 
     private SightlyParser createParser(String string) {
         SightlyLexer lexer = new SightlyLexer(new ANTLRInputStream(string));
+        lexer.removeErrorListeners();
+        lexer.addErrorListener(new SightlyParserErrorListener());
         CommonTokenStream tokenStream = new CommonTokenStream(lexer);
         SightlyParser parser = new SightlyParser(tokenStream);
         parser.removeErrorListeners();

--- a/contrib/scripting/sightly/engine/src/main/java/org/apache/sling/scripting/sightly/impl/compiler/frontend/SightlyParserErrorListener.java
+++ b/contrib/scripting/sightly/engine/src/main/java/org/apache/sling/scripting/sightly/impl/compiler/frontend/SightlyParserErrorListener.java
@@ -37,13 +37,17 @@ public class SightlyParserErrorListener extends BaseErrorListener {
     @Override
     public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg,
                             RecognitionException e) {
-        List<String> stack = ((Parser) recognizer).getRuleInvocationStack();
-        Collections.reverse(stack);
-        if (e != null) {
-            throw new SightlyParsingException(msg,
-                    ((CommonTokenStream) recognizer.getInputStream()).getTokenSource().getInputStream().toString(), e);
+        String offendingInput;
+        if (Parser.class.isAssignableFrom(recognizer.getClass())) {
+            List<String> stack = ((Parser) recognizer).getRuleInvocationStack();
+            Collections.reverse(stack);
+            offendingInput = ((CommonTokenStream) recognizer.getInputStream()).getTokenSource().getInputStream().toString();
+        } else {
+            offendingInput = recognizer.getInputStream().toString();
         }
-        throw new SightlyParsingException(msg,
-                ((CommonTokenStream) recognizer.getInputStream()).getTokenSource().getInputStream().toString());
+        if (e != null) {
+            throw new SightlyParsingException(msg, offendingInput, e);
+        }
+        throw new SightlyParsingException(msg, offendingInput);
     }
 }


### PR DESCRIPTION
- Added custom error listener to the Lexer as well, as per Sam Harwell's suggestion: http://stackoverflow.com/a/18137301/831507
- Updated the error listener to also accept Lexer recognizers.
