### PR TITLE
SLING-4500: make sure that root has a primary type

### DIFF
--- a/testing/mocks/resourceresolver-mock/src/main/java/org/apache/sling/testing/resourceresolver/MockResourceResolverFactory.java
+++ b/testing/mocks/resourceresolver-mock/src/main/java/org/apache/sling/testing/resourceresolver/MockResourceResolverFactory.java
@@ -23,20 +23,18 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Stack;
 
-import org.apache.jackrabbit.JcrConstants;
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.event.EventAdmin;
 
-import com.google.common.collect.ImmutableMap;
 
 /**
  * Simple resource resolver factory
  */
 public class MockResourceResolverFactory implements ResourceResolverFactory {
     
-    private static final String JCR_ROOT="jcr:root";
+    private static final String ROOT_PRIMARY_TYPE="rep:root";
 
     /** We use a linked hash map to preserve creation order. */
     private final Map<String, Map<String, Object>> resources = new LinkedHashMap<String, Map<String, Object>>();
@@ -64,8 +62,8 @@ public class MockResourceResolverFactory implements ResourceResolverFactory {
      */
     public MockResourceResolverFactory(final MockResourceResolverFactoryOptions options) {
         this.options = options;
-        Map<String, Object> props=ImmutableMap.<String, Object>builder()
-        .put(MockResource.JCR_PRIMARYTYPE, JCR_ROOT).build();
+        Map<String, Object> props= new HashMap<String,Object>();
+        props.put(MockResource.JCR_PRIMARYTYPE, ROOT_PRIMARY_TYPE);
         resources.put("/", props);
     }
 

--- a/testing/mocks/resourceresolver-mock/src/main/java/org/apache/sling/testing/resourceresolver/MockResourceResolverFactory.java
+++ b/testing/mocks/resourceresolver-mock/src/main/java/org/apache/sling/testing/resourceresolver/MockResourceResolverFactory.java
@@ -23,15 +23,20 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Stack;
 
+import org.apache.jackrabbit.JcrConstants;
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.event.EventAdmin;
 
+import com.google.common.collect.ImmutableMap;
+
 /**
  * Simple resource resolver factory
  */
 public class MockResourceResolverFactory implements ResourceResolverFactory {
+    
+    private static final String JCR_ROOT="jcr:root";
 
     /** We use a linked hash map to preserve creation order. */
     private final Map<String, Map<String, Object>> resources = new LinkedHashMap<String, Map<String, Object>>();
@@ -59,7 +64,9 @@ public class MockResourceResolverFactory implements ResourceResolverFactory {
      */
     public MockResourceResolverFactory(final MockResourceResolverFactoryOptions options) {
         this.options = options;
-        resources.put("/", new HashMap<String, Object>());
+        Map<String, Object> props=ImmutableMap.<String, Object>builder()
+        .put(MockResource.JCR_PRIMARYTYPE, JCR_ROOT).build();
+        resources.put("/", props);
     }
 
     @Override

--- a/testing/mocks/resourceresolver-mock/src/test/java/org/apache/sling/testing/resourceresolver/RootResourceTypeTest.java
+++ b/testing/mocks/resourceresolver-mock/src/test/java/org/apache/sling/testing/resourceresolver/RootResourceTypeTest.java
@@ -42,7 +42,7 @@ public class RootResourceTypeTest {
     @Test
     public void testIsResourceResolver() {
         Resource root= resourceResolver.getResource("/");
-        Assert.assertTrue(root.isResourceType("jcr:root"));
+        Assert.assertTrue(root.isResourceType("rep:root"));
     }
 
 }

--- a/testing/mocks/resourceresolver-mock/src/test/java/org/apache/sling/testing/resourceresolver/RootResourceTypeTest.java
+++ b/testing/mocks/resourceresolver-mock/src/test/java/org/apache/sling/testing/resourceresolver/RootResourceTypeTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.testing.resourceresolver;
+
+import java.io.IOException;
+
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class RootResourceTypeTest {
+
+
+    private ResourceResolver resourceResolver;
+
+    @Before
+    public final void setUp() throws IOException, LoginException {
+        resourceResolver = new MockResourceResolverFactory().getResourceResolver(null);       
+    }
+
+    
+    @Test
+    public void testIsResourceResolver() {
+        Resource root= resourceResolver.getResource("/");
+        Assert.assertTrue(root.isResourceType("jcr:root"));
+    }
+
+}

--- a/testing/mocks/resourceresolver-mock/src/test/java/org/apache/sling/testing/resourceresolver/SlingCrudResourceResolverTest.java
+++ b/testing/mocks/resourceresolver-mock/src/test/java/org/apache/sling/testing/resourceresolver/SlingCrudResourceResolverTest.java
@@ -20,7 +20,6 @@ package org.apache.sling.testing.resourceresolver;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -229,6 +228,5 @@ public class SlingCrudResourceResolverTest {
         assertNotNull(rootResource);
         assertEquals("/", rootResource.getPath());
     }
-
 
 }

--- a/testing/mocks/resourceresolver-mock/src/test/java/org/apache/sling/testing/resourceresolver/SlingCrudResourceResolverTest.java
+++ b/testing/mocks/resourceresolver-mock/src/test/java/org/apache/sling/testing/resourceresolver/SlingCrudResourceResolverTest.java
@@ -20,6 +20,7 @@ package org.apache.sling.testing.resourceresolver;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -227,6 +228,13 @@ public class SlingCrudResourceResolverTest {
         Resource rootResource = this.resourceResolver.resolve((String)null);
         assertNotNull(rootResource);
         assertEquals("/", rootResource.getPath());
+    }
+
+    
+    @Test
+    public void testIsResourceResolver() {
+        Resource root= resourceResolver.getResource("/");
+        assertFalse(root.isResourceType("app/resourceType"));
     }
 
 }

--- a/testing/mocks/resourceresolver-mock/src/test/java/org/apache/sling/testing/resourceresolver/SlingCrudResourceResolverTest.java
+++ b/testing/mocks/resourceresolver-mock/src/test/java/org/apache/sling/testing/resourceresolver/SlingCrudResourceResolverTest.java
@@ -230,11 +230,5 @@ public class SlingCrudResourceResolverTest {
         assertEquals("/", rootResource.getPath());
     }
 
-    
-    @Test
-    public void testIsResourceResolver() {
-        Resource root= resourceResolver.getResource("/");
-        assertFalse(root.isResourceType("app/resourceType"));
-    }
 
 }


### PR DESCRIPTION
when using the mock resource resolver, the root node does not have a primary type. this causes issues on some cases, for example:
 Resource root= resourceResolver.getResource("/");
        assertFalse(root.isResourceType("app/resourceType"));

will throw a null pointer exception.
I've added jcr:root as the primary type of the root node and a test case for this.
