### PR TITLE
SLING-4546 - Sightly: Improper handling of extension and selectors by data-sly-resource

### DIFF
--- a/contrib/scripting/sightly/testing-content/src/main/resources/SLING-INF/apps/sightly/scripts/text/text.html
+++ b/contrib/scripting/sightly/testing-content/src/main/resources/SLING-INF/apps/sightly/scripts/text/text.html
@@ -16,18 +16,5 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Sightly data-sly-resource - Sling implementation</title>
-</head>
-<body>
-<div id="selectors" data-sly-resource="${'/sightly/includedresource' @ selectors=['a', 'b']}"></div>
-<div id="selectors-remove-c" data-sly-resource="${'/sightly/includedresource.a.b.c.html' @ selectors=['a', 'b']}"></div>
-<div id="removeselectors-remove-b" data-sly-resource="${'/sightly/includedresource.a.b.c.html' @ removeSelectors=['b']}"></div>
-<div id="addselectors" data-sly-resource="${'/sightly/includedresource' @ addSelectors=['a', 'b', 'c']}"></div>
-<div id="dot-include" data-sly-resource="${ '.' @ selectors='dot'}"></div>
-<div id="extension-selectors" data-sly-resource="${'/sightly/text.a.b.txt'}"></div>
-<div id="extension-replaceselectors" data-sly-resource="${'/sightly/text.a.b.txt' @ selectors=['c']}"></div>
-</body>
-</html>
+<span class="path">path: ${resource.path}</span><br>
+<span class="selectors">selectors: ${request.requestPathInfo.selectorString}</span>

--- a/contrib/scripting/sightly/testing-content/src/main/resources/SLING-INF/sightly.json
+++ b/contrib/scripting/sightly/testing-content/src/main/resources/SLING-INF/sightly.json
@@ -16,5 +16,9 @@
     "template": {
       "jcr:primaryType": "nt:unstructured",
       "sling:resourceType": "/apps/sightly/scripts/template"
+    },
+    "text.txt": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "/apps/sightly/scripts/text"
     }
 }

--- a/contrib/scripting/sightly/testing/src/test/java/org/apache/sling/scripting/sightly/it/SlingSpecificsSightlyIT.java
+++ b/contrib/scripting/sightly/testing/src/test/java/org/apache/sling/scripting/sightly/it/SlingSpecificsSightlyIT.java
@@ -77,6 +77,10 @@ public class SlingSpecificsSightlyIT {
         assertEquals("selectors: a.c", HTMLExtractor.innerHTML(url, pageContent, "#removeselectors-remove-b span.selectors"));
         assertEquals("selectors: a.b.c", HTMLExtractor.innerHTML(url, pageContent, "#addselectors span.selectors"));
         assertEquals("It works", HTMLExtractor.innerHTML(url, pageContent, "#dot"));
+        assertEquals("path: /sightly/text.txt", HTMLExtractor.innerHTML(url, pageContent, "#extension-selectors span.path"));
+        assertEquals("selectors: a.b", HTMLExtractor.innerHTML(url, pageContent, "#extension-selectors span.selectors"));
+        assertEquals("path: /sightly/text.txt", HTMLExtractor.innerHTML(url, pageContent, "#extension-replaceselectors span.path"));
+        assertEquals("selectors: c", HTMLExtractor.innerHTML(url, pageContent, "#extension-replaceselectors span.selectors"));
     }
 
     @Test


### PR DESCRIPTION
- Improved selector extraction for resource path (taking extensions into consideration)
- Added selectors from path or parent to dispatcher options so they will no longer be ignored
- Updated testing content and integration tests
