### PR TITLE
Log appropriate error message if RUNMODE is not set on initial startup.

### DIFF
--- a/contrib/launchpad/debian/README.md
+++ b/contrib/launchpad/debian/README.md
@@ -27,6 +27,12 @@ Each of these are supported by building crank files using the sling-s3 module to
 * SLING_DATA=/var/lib/sling - Local sling data dir.
 * SLING_LOG_DIR=/var/log/sling - Sling log data.
 
+Additional bundles can be loaded in any of the defined runmodes by creating packages containing the crankstart config and dependent jars:
+/etc/sling/crank*/*.txt             - crankstart commands required
+/opt/sling/contrib.<package-name>   - additional bundle dependencies
+
+At start time, all /etc/sling/crank*/*.txt files are concatenated as defined by the /etc/sling/Makefile and sling is started with the runmode defined in /etc/default/sling. The init script link all the jars into one repo folder.
+
 TODO:
 * Support clustered configurations.
 

--- a/contrib/launchpad/debian/pom.xml
+++ b/contrib/launchpad/debian/pom.xml
@@ -136,6 +136,8 @@ under the License.
                             <goal>jdeb</goal>
                         </goals>
                         <configuration>
+                            <snapshotExpand>true</snapshotExpand>
+                            <snapshotEnv>BUILD_NUMBER</snapshotEnv>
                             <classifier>all</classifier>
                             <dataSet>
                                 <!-- etc/{default,logrotate.d}/sling - conf files -->

--- a/contrib/launchpad/debian/src/root_fs/etc/default/sling
+++ b/contrib/launchpad/debian/src/root_fs/etc/default/sling
@@ -65,7 +65,7 @@ SLING_LOG_DIR=/var/log/sling
 START_LOG_FILE=$SLING_LOG_DIR/startup.log
 
 # Define where to load dependencies from
-M2REPO="${SLING_EXEC}/contrib"
+SLING_DEPENDENCIES="${SLING_EXEC}/contrib"
 SLING_SCRIPTS=${SLING_EXEC}/scripts
 CRANKSTART_ENV=${SLING_SCRIPTS}/crankstart.sh
 

--- a/contrib/launchpad/debian/src/root_fs/etc/default/sling
+++ b/contrib/launchpad/debian/src/root_fs/etc/default/sling
@@ -63,9 +63,6 @@ SLING_DATA=/var/lib/sling
 SLING_LOG_DIR=/var/log/sling
 
 START_LOG_FILE=$SLING_LOG_DIR/startup.log
-
-# Define where to load dependencies from
-SLING_DEPENDENCIES="${SLING_EXEC}/contrib"
 SLING_SCRIPTS=${SLING_EXEC}/scripts
 CRANKSTART_ENV=${SLING_SCRIPTS}/crankstart.sh
 

--- a/contrib/launchpad/debian/src/root_fs/etc/init.d/sling
+++ b/contrib/launchpad/debian/src/root_fs/etc/init.d/sling
@@ -67,11 +67,16 @@ function start () {
 
 	# Get MVN_OPTS from crankstart env file.
 	if [ -r $CRANKSTART_ENV ] ; then
-		# Define where to load dependencies from.
-		# Other packages can use ${SLING_EXEC}.${aartigactId}
+		# Other packages can use ${SLING_EXEC}.${artifactId}
 		# for dependencies to avoid name collisions.
-		# All will be aggregated here to provide a full classpath
-		M2REPO=$(find ${SLING_EXEC} -name contrib\* -type d | tr '\n' ',' | sed -e "s/,$//")
+		# All will be aggregated here to provide a fully
+		# populated local repo.
+		M2REPO=${SLING_EXEC}/repo
+		rm -rf ${M2REPO}
+		mkdir ${M2REPO}
+		for f in ${SLING_EXEC}/contrib* ; do
+			cp -sR $f/* ${M2REPO}
+		done
 		. $CRANKSTART_ENV
 	else
 		log_failure_msg "Missing $CRANKSTART_ENV file, cannot read crankstart env settings."

--- a/contrib/launchpad/debian/src/root_fs/etc/init.d/sling
+++ b/contrib/launchpad/debian/src/root_fs/etc/init.d/sling
@@ -75,7 +75,7 @@ function start () {
 		rm -rf ${M2REPO}
 		install -d --owner=sling --group=sling  ${M2REPO}
 		for f in ${SLING_EXEC}/contrib* ; do
-			sudo -u sling "cp -sR $f/* ${M2REPO}"
+			sudo -u sling -s cp -sR $f/* ${M2REPO}
 		done
 		. $CRANKSTART_ENV
 	else

--- a/contrib/launchpad/debian/src/root_fs/etc/init.d/sling
+++ b/contrib/launchpad/debian/src/root_fs/etc/init.d/sling
@@ -75,7 +75,7 @@ function start () {
 		rm -rf ${M2REPO}
 		install -d --owner=sling --group=sling  ${M2REPO}
 		for f in ${SLING_EXEC}/contrib* ; do
-			sudo -u sling -s cp -sR $f/* ${M2REPO}
+			sudo -u sling -s cp -sRf $f/* ${M2REPO}
 		done
 		. $CRANKSTART_ENV
 	else

--- a/contrib/launchpad/debian/src/root_fs/etc/init.d/sling
+++ b/contrib/launchpad/debian/src/root_fs/etc/init.d/sling
@@ -60,13 +60,20 @@ function start () {
 
 	if [ ! "${RUNMODE}" ] ; then
 		log_warning_msg "RUNMODE is not set in ${SLING_DEFAULTS}"
+		exit -1
 	fi
 
 	check_sling_permissions
 
 	# Get MVN_OPTS from crankstart env file.
-	[ -r $CRANKSTART_ENV ] && . $CRANKSTART_ENV
-	CRANKSTART_JAR=${M2REPO}/crankstart.jar
+	if [ -r $CRANKSTART_ENV ] ; then
+		M2REPO=$SLING_DEPENDENCIES
+		. $CRANKSTART_ENV
+	else
+		log_failure_msg "Missing $CRANKSTART_ENV file, cannot read crankstart env settings."
+		exit -1
+	fi
+	CRANKSTART_JAR=${SLING_DEPENDENCIES}/crankstart.jar
 
 	# Update crankstart file if needed
 	log_daemon_msg "Starting sling serices"

--- a/contrib/launchpad/debian/src/root_fs/etc/init.d/sling
+++ b/contrib/launchpad/debian/src/root_fs/etc/init.d/sling
@@ -73,9 +73,9 @@ function start () {
 		# populated local repo.
 		M2REPO=${SLING_EXEC}/repo
 		rm -rf ${M2REPO}
-		mkdir ${M2REPO}
+		install -d --owner=sling --group=sling  ${M2REPO}
 		for f in ${SLING_EXEC}/contrib* ; do
-			cp -sR $f/* ${M2REPO}
+			sudo -u sling "cp -sR $f/* ${M2REPO}"
 		done
 		. $CRANKSTART_ENV
 	else

--- a/contrib/launchpad/debian/src/root_fs/etc/init.d/sling
+++ b/contrib/launchpad/debian/src/root_fs/etc/init.d/sling
@@ -67,13 +67,17 @@ function start () {
 
 	# Get MVN_OPTS from crankstart env file.
 	if [ -r $CRANKSTART_ENV ] ; then
-		M2REPO=$SLING_DEPENDENCIES
+		# Define where to load dependencies from.
+		# Other packages can use ${SLING_EXEC}.${aartigactId}
+		# for dependencies to avoid name collisions.
+		# All will be aggregated here to provide a full classpath
+		M2REPO=$(find ${SLING_EXEC} -name contrib\* -type d | tr '\n' ',' | sed -e "s/,$//")
 		. $CRANKSTART_ENV
 	else
 		log_failure_msg "Missing $CRANKSTART_ENV file, cannot read crankstart env settings."
 		exit -1
 	fi
-	CRANKSTART_JAR=${SLING_DEPENDENCIES}/crankstart.jar
+	CRANKSTART_JAR=${SLING_EXEC}/contrib/crankstart.jar
 
 	# Update crankstart file if needed
 	log_daemon_msg "Starting sling serices"

--- a/contrib/sling-s3/scripts/download_dependencies.rb
+++ b/contrib/sling-s3/scripts/download_dependencies.rb
@@ -13,7 +13,7 @@ DEP_PLUGIN = 'org.apache.maven.plugins:maven-dependency-plugin:2.10'
 
 # Env defaults
 $remote_repo = ENV.fetch("REMOTE_REPO",'https://repository.apache.org/content/repositories/snapshots')
-$local_repo = ENV.fetch("LOCAL_REPO",'~/.m2/repository')
+$local_repo = ENV.fetch("LOCAL_REPO", File.expand_path("~/.m2/repository"))
 # If set, copy artifacts to OUTPUT location, default is ~/.m2 only
 $output = ENV["OUTPUT"]
 
@@ -27,6 +27,7 @@ end.parse!
 
 puts "local_repo=#{$local_repo}" if $verbose
 puts "output=#{$output}" if $verbose
+FileUtils.mkdir_p $output if !$output.nil?
 
 def run cmd
   output = ""


### PR DESCRIPTION
This package requires the user to choose the mode of operation. If it's not set it was just barfing without a useful message. This adds a more helpful message as to why it didn't start.
