### PR TITLE
SLING-4562 - Sightly: Allow passing of custom options to the I18n extension

### DIFF
--- a/contrib/scripting/sightly/engine/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/I18nRuntimeExtension.java
+++ b/contrib/scripting/sightly/engine/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/I18nRuntimeExtension.java
@@ -20,6 +20,7 @@ package org.apache.sling.scripting.sightly.impl.engine.extension;
 
 import java.util.Enumeration;
 import java.util.Locale;
+import java.util.Map;
 import java.util.ResourceBundle;
 
 import javax.script.Bindings;
@@ -52,10 +53,11 @@ public class I18nRuntimeExtension implements RuntimeExtension {
     @Override
     public Object call(final RenderContext renderContext, Object... arguments) {
         RenderContextImpl renderContextImpl = (RenderContextImpl) renderContext;
-        ExtensionUtils.checkArgumentCount(I18nFilter.FUNCTION, arguments, 3);
+        ExtensionUtils.checkArgumentCount(I18nFilter.FUNCTION, arguments, 2);
         String text = renderContextImpl.toString(arguments[0]);
-        String locale = renderContextImpl.toString(arguments[1]);
-        String hint = renderContextImpl.toString(arguments[2]);
+        Map<String, Object> options = (Map<String, Object>) arguments[1];
+        String locale = renderContextImpl.toString(options.get(I18nFilter.LOCALE_OPTION));
+        String hint = renderContextImpl.toString(options.get(I18nFilter.HINT_OPTION));
         final Bindings bindings = renderContextImpl.getBindings();
         return get(bindings, text, locale, hint);
     }

--- a/contrib/scripting/sightly/engine/src/main/java/org/apache/sling/scripting/sightly/impl/filter/I18nFilter.java
+++ b/contrib/scripting/sightly/engine/src/main/java/org/apache/sling/scripting/sightly/impl/filter/I18nFilter.java
@@ -24,7 +24,7 @@ import org.apache.felix.scr.annotations.Property;
 import org.apache.felix.scr.annotations.Service;
 import org.apache.sling.scripting.sightly.impl.compiler.expression.Expression;
 import org.apache.sling.scripting.sightly.impl.compiler.expression.ExpressionNode;
-import org.apache.sling.scripting.sightly.impl.compiler.expression.node.NullLiteral;
+import org.apache.sling.scripting.sightly.impl.compiler.expression.node.MapLiteral;
 import org.apache.sling.scripting.sightly.impl.compiler.expression.node.RuntimeCall;
 
 /**
@@ -47,17 +47,7 @@ public class I18nFilter extends FilterComponent {
                 == ExpressionContext.PLUGIN_DATA_SLY_TEMPLATE || expressionContext == ExpressionContext.PLUGIN_DATA_SLY_CALL) {
             return expression;
         }
-        ExpressionNode hint = option(expression, HINT_OPTION);
-        ExpressionNode locale = option(expression, LOCALE_OPTION);
-        ExpressionNode translation = new RuntimeCall(FUNCTION, expression.getRoot(), locale, hint);
+        ExpressionNode translation = new RuntimeCall(FUNCTION, expression.getRoot(), new MapLiteral(expression.getOptions()));
         return expression.withNode(translation).withRemovedOptions(HINT_OPTION, LOCALE_OPTION);
-    }
-
-    private ExpressionNode option(Expression expression, String optionName) {
-        ExpressionNode node = expression.getOption(optionName);
-        if (node == null) {
-            return NullLiteral.INSTANCE;
-        }
-        return node;
     }
 }


### PR DESCRIPTION
- Changed the I18nFilter to pass all options to the extension call
- Changed the I18nRuntimeExtension to extract locale and hint for the options map
