### PR TITLE
SLING-4639 - SlingAdaptToAttrProcessor to support Sling Models in Thymeleaf scripting engine

### DIFF
--- a/contrib/scripting/thymeleaf/pom.xml
+++ b/contrib/scripting/thymeleaf/pom.xml
@@ -103,6 +103,12 @@
       <version>2.2.8</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.commons.classloader</artifactId>
+      <version>1.3.2</version>
+      <scope>provided</scope>
+    </dependency>
     <!-- Apache Felix -->
     <dependency>
       <groupId>org.apache.felix</groupId>

--- a/contrib/scripting/thymeleaf/src/main/java/org/apache/sling/scripting/thymeleaf/internal/dialect/SlingDialect.java
+++ b/contrib/scripting/thymeleaf/src/main/java/org/apache/sling/scripting/thymeleaf/internal/dialect/SlingDialect.java
@@ -25,12 +25,7 @@ import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.Properties;
 import org.apache.felix.scr.annotations.Property;
 import org.apache.felix.scr.annotations.Service;
-import org.apache.sling.scripting.thymeleaf.internal.processor.attr.SlingAddSelectorsAttrProcessor;
-import org.apache.sling.scripting.thymeleaf.internal.processor.attr.SlingIncludeAttrProcessor;
-import org.apache.sling.scripting.thymeleaf.internal.processor.attr.SlingReplaceSelectorsAttrProcessor;
-import org.apache.sling.scripting.thymeleaf.internal.processor.attr.SlingReplaceSuffixAttrProcessor;
-import org.apache.sling.scripting.thymeleaf.internal.processor.attr.SlingResourceTypeAttrProcessor;
-import org.apache.sling.scripting.thymeleaf.internal.processor.attr.SlingUnwrapAttrProcessor;
+import org.apache.sling.scripting.thymeleaf.internal.processor.attr.*;
 import org.osgi.framework.Constants;
 import org.thymeleaf.dialect.AbstractDialect;
 import org.thymeleaf.processor.IProcessor;
@@ -63,6 +58,7 @@ public final class SlingDialect extends AbstractDialect {
         processors.add(new SlingReplaceSuffixAttrProcessor());
         processors.add(new SlingResourceTypeAttrProcessor());
         processors.add(new SlingUnwrapAttrProcessor());
+        processors.add(new SlingAdaptToAttrProcessor());
         return processors;
     }
 

--- a/contrib/scripting/thymeleaf/src/main/java/org/apache/sling/scripting/thymeleaf/internal/dialect/SlingDialect.java
+++ b/contrib/scripting/thymeleaf/src/main/java/org/apache/sling/scripting/thymeleaf/internal/dialect/SlingDialect.java
@@ -21,10 +21,8 @@ package org.apache.sling.scripting.thymeleaf.internal.dialect;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.Properties;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Service;
+import org.apache.felix.scr.annotations.*;
+import org.apache.sling.commons.classloader.DynamicClassLoaderManager;
 import org.apache.sling.scripting.thymeleaf.internal.processor.attr.*;
 import org.osgi.framework.Constants;
 import org.thymeleaf.dialect.AbstractDialect;
@@ -44,6 +42,9 @@ public final class SlingDialect extends AbstractDialect {
 
     public static final String PREFIX = "sling";
 
+    @Reference
+    private DynamicClassLoaderManager dynamicClassLoaderManager;
+
     @Override
     public String getPrefix() {
         return PREFIX;
@@ -58,7 +59,7 @@ public final class SlingDialect extends AbstractDialect {
         processors.add(new SlingReplaceSuffixAttrProcessor());
         processors.add(new SlingResourceTypeAttrProcessor());
         processors.add(new SlingUnwrapAttrProcessor());
-        processors.add(new SlingAdaptToAttrProcessor());
+        processors.add(new SlingAdaptToAttrProcessor(dynamicClassLoaderManager));
         return processors;
     }
 

--- a/contrib/scripting/thymeleaf/src/main/java/org/apache/sling/scripting/thymeleaf/internal/processor/attr/SlingAdaptToAttrProcessor.java
+++ b/contrib/scripting/thymeleaf/src/main/java/org/apache/sling/scripting/thymeleaf/internal/processor/attr/SlingAdaptToAttrProcessor.java
@@ -24,8 +24,12 @@ public class SlingAdaptToAttrProcessor extends AbstractAttrProcessor {
 	public static final String VAR_ATTRIBUTE_NAME = "data-sling-var";
 	public static final String ADAPTABLE_ATTRIBUTE_NAME = "data-sling-adaptable";
 
-	public SlingAdaptToAttrProcessor() {
+	private DynamicClassLoaderManager dynamicClassLoaderManager;
+
+
+	public SlingAdaptToAttrProcessor(DynamicClassLoaderManager dynamicClassLoaderManager) {
 		super(ATTRIBUTE_NAME);
+		this.dynamicClassLoaderManager = dynamicClassLoaderManager;
 	}
 
 	@Override
@@ -46,7 +50,7 @@ public class SlingAdaptToAttrProcessor extends AbstractAttrProcessor {
 			final Configuration configuration = arguments.getConfiguration();
 			final IStandardExpressionParser parser = StandardExpressions.getExpressionParser(configuration);
 			final IStandardExpression expression = parser.parseExpression(configuration, arguments, adaptableValue);
-			final Adaptable adaptable = (Adaptable) expression.execute(configuration, arguments);
+			Adaptable adaptable = (Adaptable) expression.execute(configuration, arguments);
 
 			Class<?> adaptToClass = classLoader.loadClass(adaptTo);
 
@@ -72,6 +76,10 @@ public class SlingAdaptToAttrProcessor extends AbstractAttrProcessor {
 	}
 
 	private ClassLoader getClassLoader(SlingHttpServletRequest request){
+		if(dynamicClassLoaderManager != null){
+			return dynamicClassLoaderManager.getDynamicClassLoader();
+		}
+
 		final SlingBindings bindings = (SlingBindings) request.getAttribute(SlingBindings.class.getName());
 		final SlingScriptHelper scriptHelper = bindings.getSling();
 		final DynamicClassLoaderManager dynamicClassLoaderManager = scriptHelper.getService(DynamicClassLoaderManager.class);

--- a/contrib/scripting/thymeleaf/src/main/java/org/apache/sling/scripting/thymeleaf/internal/processor/attr/SlingAdaptToAttrProcessor.java
+++ b/contrib/scripting/thymeleaf/src/main/java/org/apache/sling/scripting/thymeleaf/internal/processor/attr/SlingAdaptToAttrProcessor.java
@@ -1,0 +1,81 @@
+package org.apache.sling.scripting.thymeleaf.internal.processor.attr;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.adapter.Adaptable;
+import org.apache.sling.api.scripting.SlingBindings;
+import org.apache.sling.api.scripting.SlingScriptHelper;
+import org.apache.sling.commons.classloader.DynamicClassLoaderManager;
+import org.apache.sling.scripting.thymeleaf.internal.SlingWebContext;
+import org.thymeleaf.Arguments;
+import org.thymeleaf.Configuration;
+import org.thymeleaf.dom.Element;
+import org.thymeleaf.processor.ProcessorResult;
+import org.thymeleaf.processor.attr.AbstractAttrProcessor;
+import org.thymeleaf.standard.expression.IStandardExpression;
+import org.thymeleaf.standard.expression.IStandardExpressionParser;
+import org.thymeleaf.standard.expression.StandardExpressions;
+import org.thymeleaf.util.Validate;
+
+public class SlingAdaptToAttrProcessor extends AbstractAttrProcessor {
+
+	public static final int ATTRIBUTE_PRECEDENCE = 100;
+
+	public static final String ATTRIBUTE_NAME = "adaptTo";
+	public static final String VAR_ATTRIBUTE_NAME = "data-sling-var";
+	public static final String ADAPTABLE_ATTRIBUTE_NAME = "data-sling-adaptable";
+
+	public SlingAdaptToAttrProcessor() {
+		super(ATTRIBUTE_NAME);
+	}
+
+	@Override
+	protected ProcessorResult processAttribute(Arguments arguments, Element element, String attributeName) {
+		final SlingWebContext context = (SlingWebContext) arguments.getContext();
+		final SlingHttpServletRequest request = context.getHttpServletRequest();
+		final ClassLoader classLoader = getClassLoader(request);
+
+
+		try {
+			final String adaptTo = element.getAttributeValue(attributeName);
+			final String var = element.getAttributeValue(VAR_ATTRIBUTE_NAME);
+			final String adaptableValue = element.getAttributeValue(ADAPTABLE_ATTRIBUTE_NAME);
+
+			Validate.notEmpty(var, "var must be set");
+			Validate.notEmpty(adaptableValue, "adaptable must be set");
+
+			final Configuration configuration = arguments.getConfiguration();
+			final IStandardExpressionParser parser = StandardExpressions.getExpressionParser(configuration);
+			final IStandardExpression expression = parser.parseExpression(configuration, arguments, adaptableValue);
+			final Adaptable adaptable = (Adaptable) expression.execute(configuration, arguments);
+
+			Class<?> adaptToClass = classLoader.loadClass(adaptTo);
+
+			Object adapted = adaptable.adaptTo(adaptToClass);
+			if(adapted != null){
+				context.getVariables().put(var, adapted);
+				element.getParent().removeChild(element);
+			}
+			else {
+				throw new RuntimeException("Could not adapt from " + adaptable.getClass().getName() + " to " + adaptTo);
+			}
+
+		} catch (ClassNotFoundException e) {
+			throw new RuntimeException("Class not found: " + e.getMessage());
+		}
+
+		return ProcessorResult.OK;
+	}
+
+	@Override
+	public int getPrecedence() {
+		return ATTRIBUTE_PRECEDENCE;
+	}
+
+	private ClassLoader getClassLoader(SlingHttpServletRequest request){
+		final SlingBindings bindings = (SlingBindings) request.getAttribute(SlingBindings.class.getName());
+		final SlingScriptHelper scriptHelper = bindings.getSling();
+		final DynamicClassLoaderManager dynamicClassLoaderManager = scriptHelper.getService(DynamicClassLoaderManager.class);
+		final ClassLoader classLoader = dynamicClassLoaderManager.getDynamicClassLoader();
+		return classLoader;
+	}
+}


### PR DESCRIPTION
- Added new Thymeleaf processor which adapts object specified in data-sling-adaptabe to class specified in data-sling-adaptTo and makes object available on the template in the variable specified in data-sling-var
- Element itself will be removed after successful processing
- Example usage: 

``` html
<!--/*/ <div data-sling-adaptTo="org.apache.sling.api.resource.ValueMap" data-sling-var="properties" data-sling-adaptable="${resource}"></div> /*/-->
<h1 data-th-text="${properties['jcr:title']}">Title</h1>
```

---
##### SlingModels example

``` java
@Model(adaptables = {Resource.class})
public class MyModel {

    @Inject @Named("jcr:title")
    @Default(values = "Standard Titel")
    private String title;

    public String getTitle(){
        return this.title;
    }

}
```

``` html
<!--/*/ <div data-sling-adaptTo="com.thymeleaf.models.MyModel" data-sling-var="model" data-sling-adaptable="${resource}"></div> /*/-->
<h1 data-th-text="${model.title}">Title</h1>
```
