### PR TITLE
SLING-4715 - Event filter in ResourceEventDistributionTrigger is wrongly configured

### DIFF
--- a/contrib/extensions/distribution/core/src/main/java/org/apache/sling/distribution/trigger/impl/ResourceEventDistributionTrigger.java
+++ b/contrib/extensions/distribution/core/src/main/java/org/apache/sling/distribution/trigger/impl/ResourceEventDistributionTrigger.java
@@ -85,8 +85,7 @@ public class ResourceEventDistributionTrigger implements DistributionTrigger {
                 SlingConstants.TOPIC_RESOURCE_CHANGED, SlingConstants.TOPIC_RESOURCE_REMOVED});
         log.info("trigger agent {} on path '{}'", requestHandler, path);
 
-        properties.put(EventConstants.EVENT_FILTER, "(path=" + path + "/*)");
-        properties.put(EventConstants.EVENT_FILTER, "(!(" + DEAConstants.PROPERTY_APPLICATION + "=*))");
+        properties.put(EventConstants.EVENT_FILTER, "(&(path=" + path + "/*) (!(" + DEAConstants.PROPERTY_APPLICATION + "=*)))");
 
         ServiceRegistration triggerPathEventRegistration = bundleContext.registerService(EventHandler.class.getName(),
                 new TriggerAgentEventListener(requestHandler), properties);


### PR DESCRIPTION
You are setting event filter first to a given path and then to not handle events from other sling instances. But actually the path filter has been overriden. Probbaly you meant to have this filter configured like this.
