### PR TITLE
SLING-4753 - Commit the Resource Resolver before passing it to TenantCustomizers for setting up their own customizations

### DIFF
--- a/contrib/extensions/tenant/src/main/java/org/apache/sling/tenant/internal/TenantProviderImpl.java
+++ b/contrib/extensions/tenant/src/main/java/org/apache/sling/tenant/internal/TenantProviderImpl.java
@@ -209,6 +209,8 @@ public class TenantProviderImpl implements TenantProvider, TenantManager {
                     // create the tenant
                     Resource tenantRes = createTenantResource(adminResolver, tenantId, properties);
                     TenantImpl tenant = new TenantImpl(tenantRes);
+                    // Committing the tenant resource before passing it to customizers - SLING-4753
+                    adminResolver.commit();
                     customizeTenant(tenantRes, tenant);
                     adminResolver.commit();
 

--- a/contrib/extensions/tenant/src/main/java/org/apache/sling/tenant/internal/TenantProviderImpl.java
+++ b/contrib/extensions/tenant/src/main/java/org/apache/sling/tenant/internal/TenantProviderImpl.java
@@ -209,8 +209,6 @@ public class TenantProviderImpl implements TenantProvider, TenantManager {
                     // create the tenant
                     Resource tenantRes = createTenantResource(adminResolver, tenantId, properties);
                     TenantImpl tenant = new TenantImpl(tenantRes);
-                    // Committing the tenant resource before passing it to customizers - SLING-4753
-                    adminResolver.commit();
                     customizeTenant(tenantRes, tenant);
                     adminResolver.commit();
 


### PR DESCRIPTION
Persisting the Tenant Resource by calling commit before setting up the Tenant Customizers and passing the resolver to them, which potentially have the ability to undo all the un-committed changes on the Resolver ( including the Tenant Resource itself ) leading to all kind of weird errors like InvalidItemStateException , StaleItemStateException etc.
