### PR TITLE
SLING-5266 Export org.mozilla.javascript.ast package

### DIFF
--- a/bundles/scripting/javascript/pom.xml
+++ b/bundles/scripting/javascript/pom.xml
@@ -61,6 +61,7 @@
                         <Export-Package>
                             org.apache.sling.scripting.javascript,
                             org.mozilla.javascript;version=1.1.0,
+                            org.mozilla.javascript.ast;version=1.1.0,
                             org.mozilla.classfile;version=0.0.1,
                             org.mozilla.javascript.debug;version=0.0.1
                         </Export-Package>


### PR DESCRIPTION
Currently Sling Scripting Javascript Support only exports org.mozilla.javascript package which is sufficient for evaluating javascript using Rhino but to convert expressions to  parsed AST we need org.mozilla.javascript.ast
