### PR TITLE
SLING-5398: Fixing valid file check so it will also working on windows

### DIFF
--- a/bundles/commons/fsclassloader/src/main/java/org/apache/sling/commons/fsclassloader/impl/FSClassLoaderWebConsole.java
+++ b/bundles/commons/fsclassloader/src/main/java/org/apache/sling/commons/fsclassloader/impl/FSClassLoaderWebConsole.java
@@ -271,7 +271,7 @@ public class FSClassLoaderWebConsole extends AbstractWebConsolePlugin {
 			File parent = file.getCanonicalFile().getAbsoluteFile()
 					.getParentFile();
 			while (parent != null) {
-				if (parent.getAbsolutePath().equals(root.getAbsolutePath())) {
+				if (parent.getCanonicalPath().equals(root.getCanonicalPath())) {
 					return true;
 				}
 				parent = parent.getParentFile();


### PR DESCRIPTION
On an windows environment the isValid method always return false because the root path of the fsclassloader may contain relative path information e.g. D:\aem\crx-quickstart\opt\helpers....\launchpad\felix\bundle445\data\classes
