### PR TITLE
Implemented methods in the testing jcr-mock module:

### DIFF
--- a/testing/mocks/jcr-mock/src/main/java/org/apache/sling/testing/mock/jcr/ItemData.java
+++ b/testing/mocks/jcr-mock/src/main/java/org/apache/sling/testing/mock/jcr/ItemData.java
@@ -18,18 +18,17 @@
  */
 package org.apache.sling.testing.mock.jcr;
 
-import java.util.UUID;
-
 import javax.jcr.Item;
 import javax.jcr.Session;
 import javax.jcr.Value;
 import javax.jcr.nodetype.NodeType;
+import java.util.UUID;
 
 /**
  * Holds node and property item data independently from session.
  */
 class ItemData {
-    
+
     private final String path;
     private final String name;
     private final boolean isNode;
@@ -38,7 +37,7 @@ class ItemData {
     private Value[] values;
     private boolean isMultiple;
     private boolean isNew;
-    
+
     private ItemData(String path, boolean isNode, String uuid, NodeType nodeType) {
         this.path = path;
         this.name = ResourceUtil.getName(path);
@@ -47,11 +46,11 @@ class ItemData {
         this.nodeType = nodeType;
         this.isNew = true;
     }
-    
+
     public String getPath() {
         return path;
     }
-    
+
     public String getName() {
         return name;
     }
@@ -59,11 +58,11 @@ class ItemData {
     public boolean isNode() {
         return isNode;
     }
-    
+
     public boolean isProperty() {
         return !isNode;
     }
-    
+
     public String getUuid() {
         if (!isNode()) {
             throw new UnsupportedOperationException();
@@ -105,16 +104,15 @@ class ItemData {
         }
         this.isMultiple = isMultiple;
     }
-    
+
     public Item getItem(Session session) {
         if (isNode) {
             return new MockNode(this, session);
-        }
-        else {
+        } else {
             return new MockProperty(this, session);
         }
     }
-    
+
     public boolean isNew() {
         return isNew;
     }
@@ -131,7 +129,7 @@ class ItemData {
     @Override
     public boolean equals(Object obj) {
         if (obj instanceof ItemData) {
-            return path.equals(((ItemData)obj).path);
+            return path.equals(((ItemData) obj).path);
         }
         return false;
     }
@@ -139,9 +137,13 @@ class ItemData {
     public static ItemData newNode(String path, NodeType nodeType) {
         return new ItemData(path, true, UUID.randomUUID().toString(), nodeType);
     }
-    
+
     public static ItemData newProperty(String path) {
         return new ItemData(path, false, null, null);
     }
-    
+
+    public static ItemData newMixin(String path) {
+        return new ItemData(path, false, null, null);
+    }
+
 }

--- a/testing/mocks/jcr-mock/src/main/java/org/apache/sling/testing/mock/jcr/MockNode.java
+++ b/testing/mocks/jcr-mock/src/main/java/org/apache/sling/testing/mock/jcr/MockNode.java
@@ -476,38 +476,20 @@ class MockNode extends AbstractItem implements Node {
 
     @Override
     public void orderBefore(final String srcChildRelPath, final String destChildRelPath) throws RepositoryException {
-        NodeIterator nodes = getNodes();
-        int count = 0;
-        Integer srcNodeIndex = null;
-        Integer destNodeIndex = null;
-        while (nodes.hasNext()) {
-            Node nextNode = nodes.nextNode();
-            if (nextNode.getName().equals(srcChildRelPath)) {
-                srcNodeIndex = count;
-            } else if (nextNode.getPath().equals(destChildRelPath)) {
-                destNodeIndex = count;
-            }
-            count++;
-        }
-        if (srcNodeIndex != null && destNodeIndex != null &&
-                destNodeIndex != srcNodeIndex + 1) {
-            if (srcNodeIndex < destNodeIndex) {
-                getSession().move(srcChildRelPath, srcChildRelPath);
-            }
-            nodes = getNodes();
-            boolean move = false;
-            count = 0;
-            while (nodes.hasNext()) {
-                Node nextNode = nodes.nextNode();
-                if (count == destNodeIndex || nextNode.getName().equals(srcChildRelPath)) {
-                    move = !move;
+        Node srcChildNode = getNode(srcChildRelPath);
+        Node destChildNode = getNode(destChildRelPath);
+        int destIndex = srcChildNode.getIndex() > destChildNode.getIndex() ? destChildNode.getIndex() : destChildNode.getIndex() - 1;
+        if (srcChildNode.getIndex() != destIndex) {
+            getSession().move(srcChildNode.getPath(), srcChildNode.getPath());
+            NodeIterator nodes = getNodes();
+            int currentIndex = 0;
+            while (nodes.hasNext() && srcChildNode.getIndex() != destIndex) {
+                Node currentNode = nodes.nextNode();
+                if (currentIndex >= destIndex) {
+                    getSession().move(currentNode.getPath(), currentNode.getPath());
                 }
-                if (move) {
-                    getSession().move(nextNode.getPath(), nextNode.getPath());
-                }
-                count++;
+                currentIndex++;
             }
-
         }
     }
 

--- a/testing/mocks/jcr-mock/src/main/java/org/apache/sling/testing/mock/jcr/MockSession.java
+++ b/testing/mocks/jcr-mock/src/main/java/org/apache/sling/testing/mock/jcr/MockSession.java
@@ -348,11 +348,13 @@ class MockSession implements Session {
     public void move(final String srcAbsPath, final String destAbsPath) throws RepositoryException {
         Node srcNode = getNode(srcAbsPath);
         if (srcNode.isNode()) {
+            removeItem(srcAbsPath);
+            save();
             ItemData itemData = ItemData.newNode(destAbsPath, new MockNodeType(srcNode.getPrimaryNodeType().getName()));
             addItem(itemData);
+            save();
             Node newNode = getNode(destAbsPath);
             copyNode(newNode, srcNode);
-            removeItem(srcAbsPath);
             save();
         }
     }

--- a/testing/mocks/jcr-mock/src/test/java/org/apache/sling/testing/mock/jcr/MockSessionTest.java
+++ b/testing/mocks/jcr-mock/src/test/java/org/apache/sling/testing/mock/jcr/MockSessionTest.java
@@ -18,26 +18,14 @@
  */
 package org.apache.sling.testing.mock.jcr;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import javax.jcr.ItemNotFoundException;
-import javax.jcr.NamespaceRegistry;
-import javax.jcr.Node;
-import javax.jcr.NodeIterator;
-import javax.jcr.PathNotFoundException;
-import javax.jcr.Property;
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
-
+import com.google.common.collect.ImmutableSet;
 import org.apache.jackrabbit.JcrConstants;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableSet;
+import javax.jcr.*;
+
+import static org.junit.Assert.*;
 
 public class MockSessionTest {
 
@@ -281,6 +269,18 @@ public class MockSessionTest {
         assertTrue(session.isLive());
         session.logout();
         assertFalse(session.isLive());
+    }
+
+    @Test
+    public void testMove() throws RepositoryException {
+        String nodeNewName = "nodeMoved";
+        Node rootNode = this.session.getRootNode().addNode("parentNode");
+        Node node = rootNode.addNode("node");
+        assertTrue(rootNode.hasNode(node.getName()));
+        this.session.move(node.getPath(), rootNode.getPath() + '/' + nodeNewName);
+        assertFalse(rootNode.hasNode("node"));
+        assertTrue(rootNode.hasNode(nodeNewName));
+        assertNotNull(rootNode.getNode(nodeNewName));
     }
     
 }


### PR DESCRIPTION
This changes allow the following operations:
- Add mixin to a node
- Get node index
- Get mixin node types
- Node repositioning (node.orderBefore)
- Remove mixin
- Move node
