### PR TITLE
SLING-5629: do not prepend servlet context path on the target

### DIFF
--- a/bundles/auth/core/src/main/java/org/apache/sling/auth/core/impl/SlingAuthenticator.java
+++ b/bundles/auth/core/src/main/java/org/apache/sling/auth/core/impl/SlingAuthenticator.java
@@ -1414,7 +1414,7 @@ public class SlingAuthenticator implements Authenticator,
 
         // redirect to there
         try {
-            response.sendRedirect(request.getContextPath() + target);
+            response.sendRedirect(target);
         } catch (IOException e) {
             log.error("Failed to redirect to the page: " + target, e);
         }


### PR DESCRIPTION
Remove prepend of servlet context in redirectAfterLogout, as it is required to be in the redirection target by AuthUtil.isRedirectValid
