### PR TITLE
SLING-5752 - SimpleHttpDistributionTransport does not leverage configured scheme from distribution endpoint

### DIFF
--- a/contrib/extensions/distribution/core/src/main/java/org/apache/sling/distribution/transport/impl/SimpleHttpDistributionTransport.java
+++ b/contrib/extensions/distribution/core/src/main/java/org/apache/sling/distribution/transport/impl/SimpleHttpDistributionTransport.java
@@ -160,9 +160,10 @@ public class SimpleHttpDistributionTransport implements DistributionTransport {
     private Executor authenticate(DistributionTransportSecret secret, Executor executor) {
         Map<String, String> credentialsMap = secret.asCredentialsMap();
         if (credentialsMap != null) {
-            executor = executor.auth(new HttpHost(distributionEndpoint.getUri().getHost(), distributionEndpoint.getUri().getPort()),
+            URI uri = distributionEndpoint.getUri();
+            executor = executor.auth(new HttpHost(uri.getHost(), uri.getPort(), uri.getScheme()),
                     credentialsMap.get(USERNAME), credentialsMap.get(PASSWORD)).authPreemptive(
-                    new HttpHost(distributionEndpoint.getUri().getHost(), distributionEndpoint.getUri().getPort()));
+                    new HttpHost(uri.getHost(), uri.getPort(), uri.getScheme()));
             log.debug("authenticate user={}, endpoint={}", secret.asCredentialsMap().get(USERNAME), distributionEndpoint.getUri());
         }
         return executor;


### PR DESCRIPTION
- Pass scheme from distribution endpoint when building Executor's HttpHost
