### PR TITLE
SLING-5812 - Add option to include attributes in request scope for Sightly data-sly-resource and data-sly-include

### DIFF
--- a/bundles/scripting/sightly/engine/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/ExtensionUtils.java
+++ b/bundles/scripting/sightly/engine/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/ExtensionUtils.java
@@ -18,6 +18,10 @@
  ******************************************************************************/
 package org.apache.sling.scripting.sightly.impl.engine.extension;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.scripting.sightly.SightlyException;
 import org.apache.sling.scripting.sightly.extension.RuntimeExtension;
 
@@ -38,6 +42,30 @@ public class ExtensionUtils {
         if (arguments.length != count) {
             throw new SightlyException(String.format("Extension %s requires %d arguments", extensionName, count));
         }
+    }
+
+    /**
+     * Helper method for setting specific attributes in a {@link SlingHttpServletRequest} scope
+     *
+     * @param request              the {@link SlingHttpServletRequest}
+     * @param newRequestAttributes the {@link Map} of attributes to set
+     * @return A {@link Map} of original attributes values for substituted keys
+     */
+    public static Map<String, Object> setRequestAttributes(SlingHttpServletRequest request, Map<String, Object> newRequestAttributes) {
+        Map<String, Object> originalRequestAttributes = new LinkedHashMap<String, Object>();
+        if (newRequestAttributes != null && request != null) {
+            for (Map.Entry<String, Object> attr : newRequestAttributes.entrySet()) {
+                String key = attr.getKey();
+                Object value = attr.getValue();
+                originalRequestAttributes.put(key, request.getAttribute(key));
+                if (value == null) {
+                    request.removeAttribute(key);
+                } else {
+                    request.setAttribute(key, value);
+                }
+            }
+        }
+        return originalRequestAttributes;
     }
 
 }

--- a/bundles/scripting/sightly/engine/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/IncludeRuntimeExtension.java
+++ b/bundles/scripting/sightly/engine/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/IncludeRuntimeExtension.java
@@ -56,6 +56,7 @@ public class IncludeRuntimeExtension implements RuntimeExtension {
     private static final String OPTION_FILE = "file";
     private static final String OPTION_PREPEND_PATH = "prependPath";
     private static final String OPTION_APPEND_PATH = "appendPath";
+    private static final String OPTION_REQUEST_ATTRIBUTES = "requestAttributes";
 
 
     @Override
@@ -67,7 +68,11 @@ public class IncludeRuntimeExtension implements RuntimeExtension {
         String path = buildPath(originalPath, options);
         StringWriter output = new StringWriter();
         final Bindings bindings = renderContext.getBindings();
+        SlingHttpServletRequest request = BindingsUtils.getRequest(bindings);
+        Map originalAttributes = ExtensionUtils.setRequestAttributes(request,
+                (Map)options.remove(OPTION_REQUEST_ATTRIBUTES));
         includeScript(bindings, path, new PrintWriter(output));
+        ExtensionUtils.setRequestAttributes(request, originalAttributes);
         return output.toString();
 
     }

--- a/bundles/scripting/sightly/engine/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/ResourceRuntimeExtension.java
+++ b/bundles/scripting/sightly/engine/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/ResourceRuntimeExtension.java
@@ -69,6 +69,7 @@ public class ResourceRuntimeExtension implements RuntimeExtension {
     private static final String OPTION_REMOVE_SELECTORS = "removeSelectors";
     private static final String OPTION_ADD_SELECTORS = "addSelectors";
     private static final String OPTION_REPLACE_SELECTORS = "replaceSelectors";
+    private static final String OPTION_REQUEST_ATTRIBUTES = "requestAttributes";
 
     @Override
     public Object call(final RenderContext renderContext, Object... arguments) {
@@ -81,6 +82,9 @@ public class ResourceRuntimeExtension implements RuntimeExtension {
         PathInfo pathInfo = new PathInfo(coerceString(pathObj));
         String path = pathInfo.path;
         final Bindings bindings = renderContext.getBindings();
+        SlingHttpServletRequest request = BindingsUtils.getRequest(bindings);
+        Map originalAttributes = ExtensionUtils.setRequestAttributes(request,
+                (Map)options.remove(OPTION_REQUEST_ATTRIBUTES));
         String finalPath = buildPath(path, opts, BindingsUtils.getResource(bindings));
         String resourceType = coerceString(getAndRemoveOption(opts, OPTION_RESOURCE_TYPE));
         Map<String, String> dispatcherOptionsMap = handleSelectors(bindings, pathInfo.selectors, opts);
@@ -88,6 +92,7 @@ public class ResourceRuntimeExtension implements RuntimeExtension {
         StringWriter writer = new StringWriter();
         PrintWriter printWriter = new PrintWriter(writer);
         includeResource(bindings, printWriter, finalPath, dispatcherOptions, resourceType);
+        ExtensionUtils.setRequestAttributes(request, originalAttributes);
         return writer.toString();
     }
 

--- a/bundles/scripting/sightly/testing-content/src/main/resources/SLING-INF/apps/sightly/scripts/requestattributes/include.html
+++ b/bundles/scripting/sightly/testing-content/src/main/resources/SLING-INF/apps/sightly/scripts/requestattributes/include.html
@@ -1,0 +1,22 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<sly data-sly-use.requestattributes="requestattributes.js">
+    <div id="attrs-set" data-sly-include="${'included.html' @ requestAttributes=requestattributes.attrs}"></div>
+    <div id="attrs-unset" data-sly-include="${'included.html'}"></div>
+</sly>

--- a/bundles/scripting/sightly/testing-content/src/main/resources/SLING-INF/apps/sightly/scripts/requestattributes/included.html
+++ b/bundles/scripting/sightly/testing-content/src/main/resources/SLING-INF/apps/sightly/scripts/requestattributes/included.html
@@ -1,0 +1,19 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<sly data-sly-use.included="included.js">${included.attr}</sly>

--- a/bundles/scripting/sightly/testing-content/src/main/resources/SLING-INF/apps/sightly/scripts/requestattributes/included.js
+++ b/bundles/scripting/sightly/testing-content/src/main/resources/SLING-INF/apps/sightly/scripts/requestattributes/included.js
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ ******************************************************************************/
+use(function () {
+    return {
+        attr: request.getAttribute("testAttribute")
+    }
+});

--- a/bundles/scripting/sightly/testing-content/src/main/resources/SLING-INF/apps/sightly/scripts/requestattributes/requestattributes.html
+++ b/bundles/scripting/sightly/testing-content/src/main/resources/SLING-INF/apps/sightly/scripts/requestattributes/requestattributes.html
@@ -1,0 +1,22 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<sly data-sly-use.requestattributes="requestattributes.js">
+    <div id="attrs-set" data-sly-resource="${'/sightly/requestattributes' @ selectors='included',requestAttributes=requestattributes.attrs}"></div>
+    <div id="attrs-unset" data-sly-resource="${'/sightly/requestattributes' @ selectors='included'}"></div>
+</sly>

--- a/bundles/scripting/sightly/testing-content/src/main/resources/SLING-INF/apps/sightly/scripts/requestattributes/requestattributes.js
+++ b/bundles/scripting/sightly/testing-content/src/main/resources/SLING-INF/apps/sightly/scripts/requestattributes/requestattributes.js
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ ******************************************************************************/
+use(function () {
+    var attrs = new Packages.java.util.HashMap();
+    attrs.put("testAttribute", "testValue")
+    return {
+        attrs: attrs
+    }
+});

--- a/bundles/scripting/sightly/testing-content/src/main/resources/SLING-INF/sightly.json
+++ b/bundles/scripting/sightly/testing-content/src/main/resources/SLING-INF/sightly.json
@@ -40,5 +40,9 @@
     "update": {
         "jcr:primaryType": "nt:unstructured",
         "sling:resourceType": "/apps/sightly/scripts/update"
+    },
+    "requestattributes": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "/apps/sightly/scripts/requestattributes"
     }
 }

--- a/bundles/scripting/sightly/testing/pom.xml
+++ b/bundles/scripting/sightly/testing/pom.xml
@@ -272,6 +272,12 @@
             <version>4.4</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpmime</artifactId>
+            <version>4.4</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Dependency for running Sling performance tests -->
         <dependency>

--- a/bundles/scripting/sightly/testing/src/test/java/org/apache/sling/scripting/sightly/it/SlingSpecificsSightlyIT.java
+++ b/bundles/scripting/sightly/testing/src/test/java/org/apache/sling/scripting/sightly/it/SlingSpecificsSightlyIT.java
@@ -55,6 +55,8 @@ public class SlingSpecificsSightlyIT {
     private static final String SLING_CRLF_PKG = SLING_CRLF + ".pkg.html";
     private static final String SLING_CRLF_WRONGPKG = SLING_CRLF + ".wrongpkg.html";
     private static final String SLING_SCRIPT_UPDATE = "/sightly/update.html";
+    private static final String SLING_REQUEST_ATTRIBUTES = "/sightly/requestattributes.html";
+    private static final String SLING_REQUEST_ATTRIBUTES_INCLUDE = "/sightly/requestattributes.include.html";
 
 
     @BeforeClass
@@ -226,6 +228,22 @@ public class SlingSpecificsSightlyIT {
         String url = launchpadURL + SLING_CRLF_WRONGPKG;
         String pageContent = client.getStringContent(url, 500);
         assertTrue(pageContent.contains("Compilation errors in apps/sightly/scripts/crlf/RepoPojoWrongPkgCRLF.java"));
+    }
+
+    @Test
+    public void testRequestAttributes() {
+        String url = launchpadURL + SLING_REQUEST_ATTRIBUTES;
+        String pageContent = client.getStringContent(url, 200);
+        assertEquals("testValue", HTMLExtractor.innerHTML(url, pageContent, "#attrs-set"));
+        assertEquals("", HTMLExtractor.innerHTML(url, pageContent, "#attrs-unset"));
+    }
+
+    @Test
+    public void testRequestAttributesInclude() {
+        String url = launchpadURL + SLING_REQUEST_ATTRIBUTES_INCLUDE;
+        String pageContent = client.getStringContent(url, 200);
+        assertEquals("testValue", HTMLExtractor.innerHTML(url, pageContent, "#attrs-set"));
+        assertEquals("", HTMLExtractor.innerHTML(url, pageContent, "#attrs-unset"));
     }
 
     private void uploadFile(String fileName, String serverFileName, String url) throws IOException {


### PR DESCRIPTION
- Added new option named requestAttributes to allow setting specific attributes on data-sly-request and data-sly-include
- Added tests
