### PR TITLE
SLING-5813 - Allow a Resource to be used as a Sightly Use-Object with data-sly-use

### DIFF
--- a/bundles/scripting/sightly/engine/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/ResourceUseProvider.java
+++ b/bundles/scripting/sightly/engine/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/ResourceUseProvider.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ ******************************************************************************/
+
+package org.apache.sling.scripting.sightly.impl.engine.extension.use;
+
+import javax.script.Bindings;
+
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceUtil;
+import org.apache.sling.scripting.sightly.SightlyException;
+import org.apache.sling.scripting.sightly.impl.utils.BindingsUtils;
+import org.apache.sling.scripting.sightly.render.RenderContext;
+import org.apache.sling.scripting.sightly.use.ProviderOutcome;
+import org.apache.sling.scripting.sightly.use.UseProvider;
+import org.osgi.framework.Constants;
+
+@Component(
+        metatype = true,
+        label = "Apache Sling Scripting Sightly Resource Use Provider",
+        description = "The Java Use Provider is responsible for instantiating resource objects."
+)
+@Service(UseProvider.class)
+@Properties({
+        @Property(
+                name = Constants.SERVICE_RANKING,
+                label = "Service Ranking",
+                description = "The Service Ranking value acts as the priority with which this Use Provider is queried to return an " +
+                        "Use-object. A higher value represents a higher priority.",
+                intValue = -10,
+                propertyPrivate = false
+        )
+})
+public class ResourceUseProvider implements UseProvider {
+
+    @Override
+    public ProviderOutcome provide(String identifier, RenderContext renderContext, Bindings arguments) {
+        Bindings globalBindings = renderContext.getBindings();
+        SlingHttpServletRequest request = BindingsUtils.getRequest(globalBindings);
+        String path = normalizePath(request, identifier);
+        try {
+            Resource resource = request.getResourceResolver().getResource(path);
+            if (resource != null && !ResourceUtil.isNonExistingResource(resource)) {
+                return ProviderOutcome.success(resource);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ProviderOutcome.failure(new SightlyException(e.getMessage().toString()));
+        }
+        return ProviderOutcome.failure();
+    }
+
+    private String normalizePath(SlingHttpServletRequest request, String path) {
+        if (!path.startsWith("/")) {
+            path = request.getResource().getPath() + "/" + path;
+        }
+        return ResourceUtil.normalize(path);
+    }
+}

--- a/bundles/scripting/sightly/testing-content/src/main/resources/SLING-INF/apps/sightly/scripts/use/UseSomeJava.java
+++ b/bundles/scripting/sightly/testing-content/src/main/resources/SLING-INF/apps/sightly/scripts/use/UseSomeJava.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ ******************************************************************************/
+package apps.sightly.scripts.use;
+
+public class UseSomeJava {
+
+    public static final String data = "foobar-somejava";
+
+}

--- a/bundles/scripting/sightly/testing-content/src/main/resources/SLING-INF/apps/sightly/scripts/use/resource.html
+++ b/bundles/scripting/sightly/testing-content/src/main/resources/SLING-INF/apps/sightly/scripts/use/resource.html
@@ -1,0 +1,54 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<div id="someresource" data-sly-use.someresource="/sightly/use-someresource">
+    <div class="name">${someresource.name}</div>
+    <div class="path">${someresource.path}</div>
+    <div class="type">${someresource.resourceType}</div>
+    <div class="data">${someresource.data}</div>
+</div>
+<div id="somefolder" data-sly-use.somefolder="/sightly/use-somefolder">
+    <div class="name">${somefolder.name}</div>
+    <div class="path">${somefolder.path}</div>
+    <div class="resourceType">${somefolder.resourceType}</div>
+    <div class="data">${somefolder.data}</div>
+</div>
+<div id="sometemplate" data-sly-use.sometemplate="use-sometemplate.html">
+    <div class="name">${sometemplate.name}</div>
+    <div class="path">${sometemplate.path}</div>
+    <div class="resourceType">${sometemplate.resourceType}</div>
+    <div class="data"><sly data-sly-call="${sometemplate.data}" /></div>
+</div>
+<div id="somejava" data-sly-use.somejava="UseSomeJava">
+    <div class="name">${somejava.name}</div>
+    <div class="path">${somejava.path}</div>
+    <div class="resourceType">${somejava.resourceType}</div>
+    <div class="data">${somejava.data}</div>
+</div>
+<div id="somejs" data-sly-use.somejs="use-somejs.js">
+    <div class="name">${somejs.name}</div>
+    <div class="path">${somejs.path}</div>
+    <div class="resourceType">${somejs.resourceType}</div>
+    <div class="data">${somejs.data}</div>
+</div>
+<div id="someecma" data-sly-use.someecma="use-someecma.ecma">
+    <div class="name">${someecma.name}</div>
+    <div class="path">${someecma.path}</div>
+    <div class="resourceType">${someecma.resourceType}</div>
+    <div class="data">${someecma}</div>
+</div>

--- a/bundles/scripting/sightly/testing-content/src/main/resources/SLING-INF/apps/sightly/scripts/use/use-someecma.ecma
+++ b/bundles/scripting/sightly/testing-content/src/main/resources/SLING-INF/apps/sightly/scripts/use/use-someecma.ecma
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+ 'foobar-someecma';

--- a/bundles/scripting/sightly/testing-content/src/main/resources/SLING-INF/apps/sightly/scripts/use/use-somefile.html
+++ b/bundles/scripting/sightly/testing-content/src/main/resources/SLING-INF/apps/sightly/scripts/use/use-somefile.html
@@ -1,0 +1,19 @@
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+foobar-somefile

--- a/bundles/scripting/sightly/testing-content/src/main/resources/SLING-INF/apps/sightly/scripts/use/use-somejs.js
+++ b/bundles/scripting/sightly/testing-content/src/main/resources/SLING-INF/apps/sightly/scripts/use/use-somejs.js
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ ******************************************************************************/
+use(function () {
+    return {
+        data: "foobar-somejs"
+    }
+});

--- a/bundles/scripting/sightly/testing-content/src/main/resources/SLING-INF/apps/sightly/scripts/use/use-sometemplate.html
+++ b/bundles/scripting/sightly/testing-content/src/main/resources/SLING-INF/apps/sightly/scripts/use/use-sometemplate.html
@@ -1,0 +1,19 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<template data-sly-template.data=" @ ">foobar-sometemplate</template>

--- a/bundles/scripting/sightly/testing-content/src/main/resources/SLING-INF/sightly.json
+++ b/bundles/scripting/sightly/testing-content/src/main/resources/SLING-INF/sightly.json
@@ -40,5 +40,13 @@
     "update": {
         "jcr:primaryType": "nt:unstructured",
         "sling:resourceType": "/apps/sightly/scripts/update"
+    },
+    "use-someresource": {
+        "jcr:primaryType": "nt:unstructured",
+        "data": "foobar-someresource"
+    },
+    "use-somefolder": {
+        "jcr:primaryType": "sling:Folder",
+        "data": "foobar-somefolder"
     }
 }

--- a/bundles/scripting/sightly/testing/src/test/java/org/apache/sling/scripting/sightly/it/SlingSpecificsSightlyIT.java
+++ b/bundles/scripting/sightly/testing/src/test/java/org/apache/sling/scripting/sightly/it/SlingSpecificsSightlyIT.java
@@ -55,6 +55,7 @@ public class SlingSpecificsSightlyIT {
     private static final String SLING_CRLF_PKG = SLING_CRLF + ".pkg.html";
     private static final String SLING_CRLF_WRONGPKG = SLING_CRLF + ".wrongpkg.html";
     private static final String SLING_SCRIPT_UPDATE = "/sightly/update.html";
+    private static final String SLING_RESOURCE_USE = "/sightly/use.resource.html";
 
 
     @BeforeClass
@@ -226,6 +227,18 @@ public class SlingSpecificsSightlyIT {
         String url = launchpadURL + SLING_CRLF_WRONGPKG;
         String pageContent = client.getStringContent(url, 500);
         assertTrue(pageContent.contains("Compilation errors in apps/sightly/scripts/crlf/RepoPojoWrongPkgCRLF.java"));
+    }
+
+    @Test
+    public void testResourceUse() {
+        String url = launchpadURL + SLING_RESOURCE_USE;
+        String pageContent = client.getStringContent(url, 200);
+        assertEquals("foobar-someresource", HTMLExtractor.innerHTML(url, pageContent, "#someresource .data"));
+        assertEquals("foobar-somefolder", HTMLExtractor.innerHTML(url, pageContent, "#somefolder .data"));
+        assertEquals("foobar-sometemplate", HTMLExtractor.innerHTML(url, pageContent, "#sometemplate .data"));
+        assertEquals("foobar-somejava", HTMLExtractor.innerHTML(url, pageContent, "#somejava .data"));
+        assertEquals("foobar-somejs", HTMLExtractor.innerHTML(url, pageContent, "#somejs .data"));
+        assertEquals("foobar-someecma", HTMLExtractor.innerHTML(url, pageContent, "#someecma .data"));
     }
 
     private void uploadFile(String fileName, String serverFileName, String url) throws IOException {


### PR DESCRIPTION
- Added a new UseProvider for Resource objects
- Added tests
