### PR TITLE
SLING-6053 SlingAuthenticator identifies wrong sibling node with AuthenticationInfo

### DIFF
--- a/bundles/auth/core/src/main/java/org/apache/sling/auth/core/impl/SlingAuthenticator.java
+++ b/bundles/auth/core/src/main/java/org/apache/sling/auth/core/impl/SlingAuthenticator.java
@@ -1657,11 +1657,15 @@ public class SlingAuthenticator implements Authenticator,
         }
 
         boolean isNodeRequiresAuthHandler() {
-            if (requestPath.equalsIgnoreCase(handlerPath)) {
+            final String requestPathNoSelectors = requestPath.contains(".") ?
+                    requestPath.substring(0, requestPath.indexOf(".")) :
+                    requestPath;
+
+            if (requestPathNoSelectors.equalsIgnoreCase(handlerPath)) {
                 return true;
             }
-            if (requestPath.startsWith(handlerPath)) {
-                final String suffix = requestPath.substring(handlerPath.length());
+            if (requestPathNoSelectors.startsWith(handlerPath)) {
+                final String suffix = requestPathNoSelectors.substring(handlerPath.length());
                 //if is child node auth handler is applied;
                 return suffix.contains("/");
             }

--- a/bundles/auth/core/src/test/java/org/apache/sling/auth/core/impl/SlingAuthenticatorTest.java
+++ b/bundles/auth/core/src/test/java/org/apache/sling/auth/core/impl/SlingAuthenticatorTest.java
@@ -120,8 +120,8 @@ public class SlingAuthenticatorTest extends TestCase {
     }
 
     /**
-     * Test is KO, not working.
-     *
+     * Test is OK after commit 	424e412
+     * JIRA: SLING-6053
      * Issue can be reproduced with the following steps:
      *
      * Create node "/page"

--- a/bundles/auth/core/src/test/java/org/apache/sling/auth/core/impl/SlingAuthenticatorTest.java
+++ b/bundles/auth/core/src/test/java/org/apache/sling/auth/core/impl/SlingAuthenticatorTest.java
@@ -140,8 +140,8 @@ public class SlingAuthenticatorTest extends TestCase {
      */
     public void test_siblingNodeShouldNotHaveAuthenticationInfo() throws Throwable {
         final String AUTH_TYPE = "AUTH_TYPE_TEST";
-        final String PROTECTED_PATH = "/test";
-        final String REQUEST_NOT_PROTECTED_PATH = "/test2";
+        final String PROTECTED_PATH = "/content/en/test";
+        final String REQUEST_NOT_PROTECTED_PATH = "/content/en/test2";
 
         SlingAuthenticator slingAuthenticator = new SlingAuthenticator();
 
@@ -166,8 +166,8 @@ public class SlingAuthenticatorTest extends TestCase {
      */
     public void test_childNodeShouldHaveAuthenticationInfo() throws Throwable {
         final String AUTH_TYPE = "AUTH_TYPE_TEST";
-        final String PROTECTED_PATH = "/test";
-        final String REQUEST_CHILD_NODE = "/test/childnodetest";
+        final String PROTECTED_PATH = "/content/en/test";
+        final String REQUEST_CHILD_NODE = "/content/en/test/childnodetest";
 
         SlingAuthenticator slingAuthenticator = new SlingAuthenticator();
 
@@ -223,7 +223,7 @@ public class SlingAuthenticatorTest extends TestCase {
      * Builds an auth handler for a specific path;
      * @param authType             name of the auth for this path
      * @param authProtectedPath    path protected by the auth handler
-     * @return
+     * @return AbstractAuthenticationHandlerHolder with only an AuthenticationInfo
      */
     private AbstractAuthenticationHandlerHolder buildAuthHolderForAuthTypeAndPath(final String authType, final String authProtectedPath) {
         return new AbstractAuthenticationHandlerHolder(authProtectedPath, null) {
@@ -248,6 +248,41 @@ public class SlingAuthenticatorTest extends TestCase {
 
             }
         };
+    }
+
+    public void test_childNodeAuthenticationHandlerPath() throws Throwable {
+        final String requestPath = "/content/test/test2";
+        final String handlerPath = "/content/test";
+
+        assertTrue(new SlingAuthenticator.AuthenticationHandlerPath(requestPath, handlerPath).isNodeRequiresAuthHandler());
+    }
+
+    public void test_siblingNodeAuthenticationHandlerPath() throws Throwable {
+        final String requestPath = "/content/test2";
+        final String handlerPath = "/content/test";
+
+        assertFalse(new SlingAuthenticator.AuthenticationHandlerPath(requestPath, handlerPath).isNodeRequiresAuthHandler());
+    }
+
+    public void test_actualNodeAuthenticationHandlerPath() throws Throwable {
+        final String requestPath = "/content/test";
+        final String handlerPath = "/content/test";
+
+        assertTrue(new SlingAuthenticator.AuthenticationHandlerPath(requestPath, handlerPath).isNodeRequiresAuthHandler());
+    }
+
+    public void test_rootNodeAuthenticationHandlerPath() throws Throwable {
+        final String requestPath = "/content/test";
+        final String handlerPath = "/";
+
+        assertTrue(new SlingAuthenticator.AuthenticationHandlerPath(requestPath, handlerPath).isNodeRequiresAuthHandler());
+    }
+
+    public void test_emptyNodeAuthenticationHandlerPath() throws Throwable {
+        final String requestPath = "/content/test";
+        final String handlerPath = "";
+
+        assertTrue(new SlingAuthenticator.AuthenticationHandlerPath(requestPath, handlerPath).isNodeRequiresAuthHandler());
     }
 
 }

--- a/bundles/auth/core/src/test/java/org/apache/sling/auth/core/impl/SlingAuthenticatorTest.java
+++ b/bundles/auth/core/src/test/java/org/apache/sling/auth/core/impl/SlingAuthenticatorTest.java
@@ -18,10 +18,14 @@
  */
 package org.apache.sling.auth.core.impl;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
+import org.apache.sling.auth.core.spi.AuthenticationFeedbackHandler;
+import org.apache.sling.auth.core.spi.AuthenticationInfo;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JUnit4Mockery;
@@ -113,6 +117,137 @@ public class SlingAuthenticatorTest extends TestCase {
 
         Boolean allowed = (Boolean) PrivateAccessor.invoke(slingAuthenticator,"isAnonAllowed",  new Class[]{HttpServletRequest.class},new Object[]{request});
         assertTrue(allowed);
+    }
+
+    /**
+     * Test is KO, not working.
+     *
+     * Issue can be reproduced with the following steps:
+     *
+     * Create node "/page"
+     * Create sibling node "/page1"
+     * Define an auth handler for node: "/page"
+     *
+     * Expected: "/page" has AuthenticationInfo
+     *           "/page1" does not have AuthenticationInfo (has anonymous)
+     *
+     * Actual:  "/page" & "page1" are both having AuthenticationInfo
+     *
+     * Reason: SlingAuthenticator.java line 726:  if (path.startsWith(holder.path))
+     * Warning: The same check is used in 4 more places in code with similar behaviour.
+     *
+     * @throws Throwable
+     */
+    public void test_siblingNodeShouldNotHaveAuthenticationInfo() throws Throwable {
+        final String AUTH_TYPE = "AUTH_TYPE_TEST";
+        final String PROTECTED_PATH = "/test";
+        final String REQUEST_NOT_PROTECTED_PATH = "/test2";
+
+        SlingAuthenticator slingAuthenticator = new SlingAuthenticator();
+
+        PathBasedHolderCache<AbstractAuthenticationHandlerHolder> authRequiredCache = new PathBasedHolderCache<AbstractAuthenticationHandlerHolder>();
+        authRequiredCache.addHolder(buildAuthHolderForAuthTypeAndPath(AUTH_TYPE, PROTECTED_PATH));
+
+        PrivateAccessor.setField(slingAuthenticator, "authHandlerCache", authRequiredCache);
+        final HttpServletRequest request = context.mock(HttpServletRequest.class);
+        buildExpectationsForRequestPathAndAuthPath(request, REQUEST_NOT_PROTECTED_PATH, PROTECTED_PATH);
+
+        AuthenticationInfo authInfo = (AuthenticationInfo) PrivateAccessor.invoke(slingAuthenticator, "getAuthenticationInfo",
+                new Class[]{HttpServletRequest.class, HttpServletResponse.class}, new Object[]{request, context.mock(HttpServletResponse.class)});
+        /**
+         * The AUTH TYPE defined aboved should not be used for the path /test2.
+         */
+        assertFalse(AUTH_TYPE.equals(authInfo.getAuthType()));
+    }
+
+    /**
+     * Test is OK for child node;
+     * @throws Throwable
+     */
+    public void test_childNodeShouldHaveAuthenticationInfo() throws Throwable {
+        final String AUTH_TYPE = "AUTH_TYPE_TEST";
+        final String PROTECTED_PATH = "/test";
+        final String REQUEST_CHILD_NODE = "/test/childnodetest";
+
+        SlingAuthenticator slingAuthenticator = new SlingAuthenticator();
+
+        PathBasedHolderCache<AbstractAuthenticationHandlerHolder> authRequiredCache = new PathBasedHolderCache<AbstractAuthenticationHandlerHolder>();
+        authRequiredCache.addHolder(buildAuthHolderForAuthTypeAndPath(AUTH_TYPE, PROTECTED_PATH));
+
+        PrivateAccessor.setField(slingAuthenticator, "authHandlerCache", authRequiredCache);
+        final HttpServletRequest request = context.mock(HttpServletRequest.class);
+        buildExpectationsForRequestPathAndAuthPath(request, REQUEST_CHILD_NODE, PROTECTED_PATH);
+
+        AuthenticationInfo authInfo = (AuthenticationInfo) PrivateAccessor.invoke(slingAuthenticator, "getAuthenticationInfo",
+                new Class[]{HttpServletRequest.class, HttpServletResponse.class}, new Object[]{request, context.mock(HttpServletResponse.class)});
+        /**
+         * The AUTH TYPE defined aboved should  be used for the path /test and his children: eg /test/childnode.
+         */
+        assertTrue(AUTH_TYPE.equals(authInfo.getAuthType()));
+    }
+
+    /**
+     * Mocks the request to accept method calls on path;
+     *
+     * @param request              http request
+     * @param requestPath          path in the http request
+     * @param authProtectedPath    path protected by the auth handler
+     */
+    private void buildExpectationsForRequestPathAndAuthPath(final HttpServletRequest request,
+                                                            final String requestPath,
+                                                            final String authProtectedPath) {
+        {
+            context.checking(new Expectations() {
+                {
+                    allowing(request).getServletPath();
+                    will(returnValue(requestPath));
+                    allowing(request).getPathInfo();
+                    will(returnValue(null));
+                    allowing(request).getServerName();
+                    will(returnValue("localhost"));
+                    allowing(request).getServerPort();
+                    will(returnValue(80));
+                    allowing(request).getScheme();
+                    will(returnValue("http"));
+                    allowing(request).getAttribute("path");
+                    will(returnValue(requestPath));
+                    allowing(request).setAttribute("path", requestPath);
+                    allowing(request).setAttribute("path", authProtectedPath);
+                }
+            });
+        }
+    }
+
+
+    /**
+     * Builds an auth handler for a specific path;
+     * @param authType             name of the auth for this path
+     * @param authProtectedPath    path protected by the auth handler
+     * @return
+     */
+    private AbstractAuthenticationHandlerHolder buildAuthHolderForAuthTypeAndPath(final String authType, final String authProtectedPath) {
+        return new AbstractAuthenticationHandlerHolder(authProtectedPath, null) {
+
+            @Override
+            protected AuthenticationFeedbackHandler getFeedbackHandler() {
+                return null;
+            }
+
+            @Override
+            protected AuthenticationInfo doExtractCredentials(HttpServletRequest request, HttpServletResponse response) {
+                return new AuthenticationInfo(authType);
+            }
+
+            @Override
+            protected boolean doRequestCredentials(HttpServletRequest request, HttpServletResponse response) throws IOException {
+                return false;
+            }
+
+            @Override
+            protected void doDropCredentials(HttpServletRequest request, HttpServletResponse response) throws IOException {
+
+            }
+        };
     }
 
 }

--- a/bundles/auth/core/src/test/java/org/apache/sling/auth/core/impl/SlingAuthenticatorTest.java
+++ b/bundles/auth/core/src/test/java/org/apache/sling/auth/core/impl/SlingAuthenticatorTest.java
@@ -293,6 +293,13 @@ public class SlingAuthenticatorTest extends TestCase {
         assertFalse(new SlingAuthenticator.AuthenticationHandlerPath(requestPath, handlerPath).isNodeRequiresAuthHandler());
     }
 
+    public void test_requestPathBackSlash() throws Throwable {
+        final String requestPath = "/page1\\somesubepage";
+        final String handlerPath = "/page";
+
+        assertFalse(new SlingAuthenticator.AuthenticationHandlerPath(requestPath, handlerPath).isNodeRequiresAuthHandler());
+    }
+
 
     public void test_emptyNodeAuthenticationHandlerPath() throws Throwable {
         final String requestPath = "/content/test";
@@ -300,5 +307,7 @@ public class SlingAuthenticatorTest extends TestCase {
 
         assertTrue(new SlingAuthenticator.AuthenticationHandlerPath(requestPath, handlerPath).isNodeRequiresAuthHandler());
     }
+
+
 
 }

--- a/bundles/auth/core/src/test/java/org/apache/sling/auth/core/impl/SlingAuthenticatorTest.java
+++ b/bundles/auth/core/src/test/java/org/apache/sling/auth/core/impl/SlingAuthenticatorTest.java
@@ -258,7 +258,7 @@ public class SlingAuthenticatorTest extends TestCase {
     }
 
     public void test_siblingNodeAuthenticationHandlerPath() throws Throwable {
-        final String requestPath = "/content/test2";
+        final String requestPath = "/content/test2.html/en/2016/09/19/test.html";
         final String handlerPath = "/content/test";
 
         assertFalse(new SlingAuthenticator.AuthenticationHandlerPath(requestPath, handlerPath).isNodeRequiresAuthHandler());
@@ -277,6 +277,22 @@ public class SlingAuthenticatorTest extends TestCase {
 
         assertTrue(new SlingAuthenticator.AuthenticationHandlerPath(requestPath, handlerPath).isNodeRequiresAuthHandler());
     }
+
+    public void test_requestPathSelectorsAreTakenInConsideration() throws Throwable {
+        final String requestPath = "/content/test.selector1.selector2.html/en/2016/test.html";
+        final String handlerPath = "/content/test";
+
+        assertTrue(new SlingAuthenticator.AuthenticationHandlerPath(requestPath, handlerPath).isNodeRequiresAuthHandler());
+    }
+
+
+    public void test_requestPathSelectorsSiblingAreTakenInConsideration() throws Throwable {
+        final String requestPath = "/content/test.selector1.selector2.html/en/2016/09/19/test.html";
+        final String handlerPath = "/content/test2";
+
+        assertFalse(new SlingAuthenticator.AuthenticationHandlerPath(requestPath, handlerPath).isNodeRequiresAuthHandler());
+    }
+
 
     public void test_emptyNodeAuthenticationHandlerPath() throws Throwable {
         final String requestPath = "/content/test";


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SLING-6053 
