### PR TITLE
SLING-6110: use the proper bundleContext in the ServerSideTeleporter …

### DIFF
--- a/testing/junit/core/pom.xml
+++ b/testing/junit/core/pom.xml
@@ -123,10 +123,12 @@
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>
+            <version>4.3.0</version>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.compendium</artifactId>
+            <version>4.3.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>

--- a/testing/junit/core/src/main/java/org/apache/sling/junit/rules/ServerSideTeleporter.java
+++ b/testing/junit/core/src/main/java/org/apache/sling/junit/rules/ServerSideTeleporter.java
@@ -20,7 +20,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.sling.junit.Activator;
+import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceReference;
 
 /** Server-side variant of the TeleporterRule, which provides
@@ -33,8 +35,15 @@ class ServerSideTeleporter extends TeleporterRule {
     
     private static final int WAITFOR_SERVICE_TIMEOUT_DEFAULT_SECONDS = 10;
     
-    ServerSideTeleporter() {
-        bundleContext = Activator.getBundleContext();
+    ServerSideTeleporter(Class<?> classUnderTest) {
+        Bundle bundle = FrameworkUtil.getBundle(classUnderTest);
+
+        if (bundle != null) {
+            bundleContext = bundle.getBundleContext();
+        } else {
+            bundleContext = null;
+        }
+
         if(bundleContext == null) {
             throw new IllegalStateException("Null BundleContext, should not happen when this class is used");
         }

--- a/testing/junit/core/src/main/java/org/apache/sling/junit/rules/TeleporterRule.java
+++ b/testing/junit/core/src/main/java/org/apache/sling/junit/rules/TeleporterRule.java
@@ -78,7 +78,7 @@ public abstract class TeleporterRule extends ExternalResource {
         TeleporterRule result = null;
         
         if(isServerSide()) {
-            result = new ServerSideTeleporter();
+            result = new ServerSideTeleporter(classUnderTest);
         } else {
             // Client-side. Instantiate the class dynamically to 
             // avoid bringing its dependencies into this module when


### PR DESCRIPTION
…to retrieve the correct bundle headers
