### PR TITLE
Ability to specify TTL for separate health check

### DIFF
--- a/bundles/extensions/healthcheck/annotations/src/main/java/org/apache/sling/hc/annotations/SlingHealthCheck.java
+++ b/bundles/extensions/healthcheck/annotations/src/main/java/org/apache/sling/hc/annotations/SlingHealthCheck.java
@@ -80,4 +80,11 @@ public @interface SlingHealthCheck {
     /** This is generally used as a description for the object described by the meta type. This name may be localized by prepending a % sign to the name. Default
      * value: %&lt;name&gt;.description */
     String description() default "";
+
+    /**
+     * Override global result TTL for Health Check.
+     * The value of this property must be of type {@link Long}.
+     * @return TTL cached result in ms
+     */
+    long resultCacheTtlInMs() default -1;
 }

--- a/bundles/extensions/healthcheck/annotations/src/main/java/org/apache/sling/hc/annotations/SlingHealthCheckProcessor.java
+++ b/bundles/extensions/healthcheck/annotations/src/main/java/org/apache/sling/hc/annotations/SlingHealthCheckProcessor.java
@@ -90,6 +90,7 @@ public class SlingHealthCheckProcessor implements AnnotationProcessor {
         generateStringPropertyDescriptor(cad, classDescription, metatype, "tags", HealthCheck.TAGS, "Tags", "Tags", true);
         generateStringPropertyDescriptor(cad, classDescription, metatype, "mbeanName", HealthCheck.MBEAN_NAME, "MBean", "MBean name (leave empty for not using JMX)", false);
         generateStringPropertyDescriptor(cad, classDescription, metatype, "asyncCronExpression", "hc.async.cronExpression" /* use constant once API is released */ , "Cron expression", "Cron expression for asynchronous execution (leave empty for synchronous execution)", false);
+        generateStringPropertyDescriptor(cad, classDescription, metatype, "resultCacheTtlInMs", "hc.resultCacheTtlInMs" /* use constant once API is released */ , "Result Cache TTL", "Result Cache TTL which will override global configured value for this service", false);
     }
 
     /** Generates a property descriptor of type {@link PropertyType#String[]} */

--- a/bundles/extensions/healthcheck/core/src/main/java/org/apache/sling/hc/api/HealthCheck.java
+++ b/bundles/extensions/healthcheck/core/src/main/java/org/apache/sling/hc/api/HealthCheck.java
@@ -68,10 +68,10 @@ public interface HealthCheck {
     String ASYNC_CRON_EXPRESSION = "hc.async.cronExpression";
 
     /**
-     * Optional service property: Time To Leave for health check {@link Result}.
+     * Optional service property: Time To Live for health check {@link Result}.
      * The value of this property must be of type {@link Long}.
      */
-    String TTL = "hc.ttl";
+    String RESULT_CACHE_TTL_IN_MS = "hc.resultCacheTtlInMs";
 
     /**
      * Execute this health check and return a {@link Result}

--- a/bundles/extensions/healthcheck/core/src/main/java/org/apache/sling/hc/api/HealthCheck.java
+++ b/bundles/extensions/healthcheck/core/src/main/java/org/apache/sling/hc/api/HealthCheck.java
@@ -66,7 +66,13 @@ public interface HealthCheck {
      * will be executed asynchronously using the cron expression provided.
      */
     String ASYNC_CRON_EXPRESSION = "hc.async.cronExpression";
-    
+
+    /**
+     * Optional service property: Time To Leave for health check {@link Result}.
+     * The value of this property must be of type {@link Long}.
+     */
+    String TTL = "hc.ttl";
+
     /**
      * Execute this health check and return a {@link Result}
      * This is meant to execute quickly, access to external

--- a/bundles/extensions/healthcheck/core/src/main/java/org/apache/sling/hc/api/package-info.java
+++ b/bundles/extensions/healthcheck/core/src/main/java/org/apache/sling/hc/api/package-info.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-@Version("1.0.1")
+@Version("1.1.0")
 package org.apache.sling.hc.api;
 
 import aQute.bnd.annotation.Version;

--- a/bundles/extensions/healthcheck/core/src/main/java/org/apache/sling/hc/core/impl/executor/HealthCheckExecutorImpl.java
+++ b/bundles/extensions/healthcheck/core/src/main/java/org/apache/sling/hc/core/impl/executor/HealthCheckExecutorImpl.java
@@ -92,7 +92,7 @@ public class HealthCheckExecutorImpl implements ExtendedHealthCheckExecutor, Ser
 
     private static final long RESULT_CACHE_TTL_DEFAULT_MS = 1000 * 2;
     public static final String PROP_RESULT_CACHE_TTL_MS = "resultCacheTtlInMs";
-    @Property(name = PROP_RESULT_CACHE_TTL_MS, label = "Results Cache TTL in Ms",
+    @Property(name = PROP_RESULT_CACHE_TTL_MS, label = "Results Cache RESULT_CACHE_TTL_IN_MS in Ms",
             description = "Result Cache time to live - results will be cached for the given time",
             longValue = RESULT_CACHE_TTL_DEFAULT_MS)
 
@@ -454,7 +454,7 @@ public class HealthCheckExecutorImpl implements ExtendedHealthCheckExecutor, Ser
                         + msHumanReadable(this.longRunningFutureThresholdForRedMs) + ")");
             }
 
-            // add logs from previous, cached result if exists (using a 1 year TTL)
+            // add logs from previous, cached result if exists (using a 1 year RESULT_CACHE_TTL_IN_MS)
             HealthCheckExecutionResult lastCachedResult = healthCheckResultCache.getValidCacheResult(hcMetadata, 1000 * 60 * 60 * 24 * 365);
             if (lastCachedResult != null) {
                 DateFormat df = new SimpleDateFormat("HH:mm:ss.SSS");

--- a/bundles/extensions/healthcheck/core/src/main/java/org/apache/sling/hc/core/impl/executor/HealthCheckResultCache.java
+++ b/bundles/extensions/healthcheck/core/src/main/java/org/apache/sling/hc/core/impl/executor/HealthCheckResultCache.java
@@ -42,6 +42,11 @@ public class HealthCheckResultCache {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     /**
+     * Minimal TTL value for cached item
+     */
+    private final long MIN_TTL = 0;
+
+    /**
      * The map holding the cached results.
      */
     private final Map<Long, HealthCheckExecutionResult> cache = new ConcurrentHashMap<Long, HealthCheckExecutionResult>();
@@ -94,7 +99,7 @@ public class HealthCheckResultCache {
             }
 
             // Option: add resultCacheTtlInMs as property to health check to make it configurable per check
-            Date validUntil = new Date(finishedAt.getTime() + resultCacheTtlInMs);
+            Date validUntil = new Date(finishedAt.getTime() + getTtl(metadata, resultCacheTtlInMs));
             Date now = new Date();
             if (validUntil.after(now)) {
                 logger.debug("Cache hit: validUntil={} cachedResult={}", validUntil, cachedResult);
@@ -107,6 +112,22 @@ public class HealthCheckResultCache {
 
         // null => no cache hit
         return null;
+    }
+
+    /**
+     * Try to obtain {@link org.apache.sling.hc.api.Result} TTL from metadata if specified
+     * @param metadata for health check service
+     * @param defaultTtl from service configuration
+     * @return TTL from metadata if specified, default - otherwise
+     */
+    private long getTtl(HealthCheckMetadata metadata, long defaultTtl){
+        final long ttl;
+        if(metadata != null && metadata.getTtl() >= MIN_TTL){
+            ttl = metadata.getTtl();
+        } else {
+            ttl = defaultTtl;
+        }
+        return ttl;
     }
 
     /**

--- a/bundles/extensions/healthcheck/core/src/main/java/org/apache/sling/hc/core/impl/executor/HealthCheckResultCache.java
+++ b/bundles/extensions/healthcheck/core/src/main/java/org/apache/sling/hc/core/impl/executor/HealthCheckResultCache.java
@@ -42,9 +42,9 @@ public class HealthCheckResultCache {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     /**
-     * Minimal TTL value for cached item
+     * If no TTL value was specified for service
      */
-    private static final long MIN_TTL = 0;
+    private static final long RESULT_CACHE_TTL_UNDEFINED = -1;
 
     /**
      * The map holding the cached results.
@@ -116,14 +116,15 @@ public class HealthCheckResultCache {
 
     /**
      * Try to obtain {@link org.apache.sling.hc.api.Result} TTL from metadata if specified
-     * @param metadata for health check service
+     *
+     * @param metadata   for health check service
      * @param defaultTtl from service configuration
      * @return TTL from metadata if specified, default - otherwise
      */
-    private long getTtl(HealthCheckMetadata metadata, long defaultTtl){
+    private long getTtl(HealthCheckMetadata metadata, long defaultTtl) {
         final long ttl;
-        if(metadata != null && metadata.getTtl() >= MIN_TTL){
-            ttl = metadata.getTtl();
+        if (metadata.getResultCacheTtlInMs() != null && metadata.getResultCacheTtlInMs() > RESULT_CACHE_TTL_UNDEFINED) {
+            ttl = metadata.getResultCacheTtlInMs();
         } else {
             ttl = defaultTtl;
         }

--- a/bundles/extensions/healthcheck/core/src/main/java/org/apache/sling/hc/core/impl/executor/HealthCheckResultCache.java
+++ b/bundles/extensions/healthcheck/core/src/main/java/org/apache/sling/hc/core/impl/executor/HealthCheckResultCache.java
@@ -44,7 +44,7 @@ public class HealthCheckResultCache {
     /**
      * Minimal TTL value for cached item
      */
-    private final long MIN_TTL = 0;
+    private static final long MIN_TTL = 0;
 
     /**
      * The map holding the cached results.

--- a/bundles/extensions/healthcheck/core/src/main/java/org/apache/sling/hc/util/HealthCheckMetadata.java
+++ b/bundles/extensions/healthcheck/core/src/main/java/org/apache/sling/hc/util/HealthCheckMetadata.java
@@ -47,6 +47,10 @@ public class HealthCheckMetadata {
 
     private final transient ServiceReference serviceReference;
 
+    private final long ttl;
+
+    private final static long NOT_CONFIGURED_TTL = -1;
+
     public HealthCheckMetadata(final ServiceReference ref) {
         this.serviceId = (Long) ref.getProperty(Constants.SERVICE_ID);
         this.name = (String) ref.getProperty(HealthCheck.NAME);
@@ -54,6 +58,8 @@ public class HealthCheckMetadata {
         this.title = getHealthCheckTitle(ref);
         this.tags = arrayPropertyToListOfStr(ref.getProperty(HealthCheck.TAGS));
         this.asyncCronExpression = (String) ref.getProperty(HealthCheck.ASYNC_CRON_EXPRESSION);
+        final Long ttlTemp = PropertiesUtil.toLong(ref.getProperty(HealthCheck.TTL), NOT_CONFIGURED_TTL);
+        this.ttl = ttlTemp != null ? ttlTemp : NOT_CONFIGURED_TTL;
         this.serviceReference = ref;
     }
 
@@ -114,6 +120,14 @@ public class HealthCheckMetadata {
      */
     public ServiceReference getServiceReference() {
         return this.serviceReference;
+    }
+
+    /**
+     * Get service {@link org.apache.sling.hc.api.Result} Time To Leave
+     * @return actual time in ms for {@link org.apache.sling.hc.api.Result} for leave in cache
+     */
+    public long getTtl() {
+        return ttl;
     }
 
     @Override

--- a/bundles/extensions/healthcheck/core/src/main/java/org/apache/sling/hc/util/HealthCheckMetadata.java
+++ b/bundles/extensions/healthcheck/core/src/main/java/org/apache/sling/hc/util/HealthCheckMetadata.java
@@ -47,9 +47,7 @@ public class HealthCheckMetadata {
 
     private final transient ServiceReference serviceReference;
 
-    private final long ttl;
-
-    private final static long NOT_CONFIGURED_TTL = -1;
+    private final Long resultCacheTtlInMs;
 
     public HealthCheckMetadata(final ServiceReference ref) {
         this.serviceId = (Long) ref.getProperty(Constants.SERVICE_ID);
@@ -58,8 +56,7 @@ public class HealthCheckMetadata {
         this.title = getHealthCheckTitle(ref);
         this.tags = arrayPropertyToListOfStr(ref.getProperty(HealthCheck.TAGS));
         this.asyncCronExpression = (String) ref.getProperty(HealthCheck.ASYNC_CRON_EXPRESSION);
-        final Long ttlTemp = PropertiesUtil.toLong(ref.getProperty(HealthCheck.TTL), NOT_CONFIGURED_TTL);
-        this.ttl = ttlTemp != null ? ttlTemp : NOT_CONFIGURED_TTL;
+        this.resultCacheTtlInMs = (Long)ref.getProperty(HealthCheck.RESULT_CACHE_TTL_IN_MS);
         this.serviceReference = ref;
     }
 
@@ -123,11 +120,11 @@ public class HealthCheckMetadata {
     }
 
     /**
-     * Get service {@link org.apache.sling.hc.api.Result} Time To Leave
-     * @return actual time in ms for {@link org.apache.sling.hc.api.Result} for leave in cache
+     * Get service {@link org.apache.sling.hc.api.Result} Time To Live
+     * @return actual time in ms for {@link org.apache.sling.hc.api.Result} live in cache
      */
-    public long getTtl() {
-        return ttl;
+    public Long getResultCacheTtlInMs() {
+        return resultCacheTtlInMs;
     }
 
     @Override

--- a/bundles/extensions/healthcheck/core/src/main/java/org/apache/sling/hc/util/package-info.java
+++ b/bundles/extensions/healthcheck/core/src/main/java/org/apache/sling/hc/util/package-info.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-@Version("1.2.0")
+@Version("1.3.0")
 package org.apache.sling.hc.util;
 
 import aQute.bnd.annotation.Version;


### PR DESCRIPTION
Added ability to specify TTL for separate health check in case of expensive computations.
If property "hc.ttl" specified within HC - it will be used as TTL for result, otherwise default TTL value

**Ex.**: in my case "hc" validating repository about 3-5 minutes therefore I couldn't specify TTL globally to not impact on other "hc" results. This check I couldn't execute by scheduler due to CPU loading, also results for this check results remain relevant for an hour.

Ticket for this request: https://issues.apache.org/jira/browse/SLING-6126
