### PR TITLE
SLING-6422, Allow for specifying oak restrictions with repoinit

### DIFF
--- a/bundles/extensions/repoinit/parser/src/main/java/org/apache/sling/repoinit/parser/operations/AclLine.java
+++ b/bundles/extensions/repoinit/parser/src/main/java/org/apache/sling/repoinit/parser/operations/AclLine.java
@@ -42,6 +42,7 @@ public class AclLine {
     };
     
     private final Map<String, List<String>> properties;
+    private List<RestrictionClause> restrictions;
     
     public AclLine(Action a) {
         action = a;
@@ -63,9 +64,16 @@ public class AclLine {
     public void setProperty(String name, List<String> values) {
         properties.put(name, Collections.unmodifiableList(values));
     }
+
+    public void setRestrictions(List<RestrictionClause> restrictions){
+        this.restrictions = restrictions;
+    }
+
+    public List<RestrictionClause> getRestrictions() { return this.restrictions; }
     
     @Override
     public String toString() {
-        return getClass().getSimpleName() + " " + action + " " + properties;
+        return getClass().getSimpleName() + " " + action + " " + properties + (restrictions == null || restrictions.isEmpty() ? "" : " restrictions="+restrictions);
+
     }
 }

--- a/bundles/extensions/repoinit/parser/src/main/java/org/apache/sling/repoinit/parser/operations/RestrictionClause.java
+++ b/bundles/extensions/repoinit/parser/src/main/java/org/apache/sling/repoinit/parser/operations/RestrictionClause.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -6,15 +6,41 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
-@org.osgi.annotation.versioning.Version("3.1.0")
+ */
 package org.apache.sling.repoinit.parser.operations;
 
+import java.util.List;
+
+/**
+ * Single restriction(name,values*)
+ */
+public final class RestrictionClause {
+
+    private final String name;
+    private final List<String> values;
+
+    public RestrictionClause(final String name,final List<String> values){
+        this.name = name;
+        this.values = values;
+    }
+
+    public String getName(){
+        return name;
+    }
+
+    public List<String> getValues(){
+        return values;
+    }
+
+    @Override
+    public String toString(){
+        return name + "=" + values;
+    }
+}

--- a/bundles/extensions/repoinit/parser/src/main/javacc/RepoInitGrammar.jjt
+++ b/bundles/extensions/repoinit/parser/src/main/javacc/RepoInitGrammar.jjt
@@ -78,11 +78,12 @@ TOKEN:
 |   < RCURLY: "}" >
 |   < COMMA: "," >
 |   < STAR: "*" >
+|   < RESTRICTION: "restriction" >
 
 /* The order of these fuzzy statements is important (first match wins?) */ 
 |   < NAMESPACED_ITEM: (["a"-"z"] | ["A"-"Z"])+ ":" (["a"-"z"] | ["A"-"Z"])+ >
 |   < PATH_STRING: "/" (["a"-"z"] | ["A"-"Z"] | ["0"-"9"] | ["-"] | ["_"] | ["."] | ["/"]) * >
-|   < STRING: (["a"-"z"] | ["A"-"Z"] | ["0"-"9"] | ["-"] | ["_"] | ["."] | ["/"] | [":"]) * >
+|   < STRING: (["a"-"z"] | ["A"-"Z"] | ["0"-"9"] | ["-"] | ["_"] | ["."] | ["/"] | [":"] | ["*"]) * >
 |   < EOL: "\n" >
 }
 
@@ -255,29 +256,95 @@ void userPrivilegesLine(List<AclLine> lines) :
 {
     AclLine line;
     List<String> tmp;
+    List<RestrictionClause> restrictions;
 }
 {
     line = privilegesLineOperation()
-    tmp = namespacedItemsList() { line.setProperty(AclLine.PROP_PRIVILEGES, tmp); } 
+    tmp = namespacedItemsList() { line.setProperty(AclLine.PROP_PRIVILEGES, tmp); }
     <FOR>
     tmp = principalsList() { line.setProperty(AclLine.PROP_PRINCIPALS, tmp); }
+    restrictions = parseRestrictions()  { line.setRestrictions(restrictions); }
     <EOL>
 
     {   
         lines.add(line); 
     }
 }
+/**
+ * Parses a single restriction value
+ */
+void parseRestrictionValue(List<String> values) :
+{
+   Token t;
+}
+{
+   <COMMA> ( t=<STAR> | t=<NAMESPACED_ITEM> | t=<PATH_STRING> | t=<STRING> )
+   {
+       values.add(t.image);
+   }
+}
+
+/**
+ * parses list of restriction values
+ */
+List<String> parseRestrictionValues() :
+{
+    List<String> values = new ArrayList<String>();
+}
+{
+    ( parseRestrictionValue(values) ) *
+
+    {
+        return values;
+    }
+
+}
+
+
+/**
+ * parses a single restriction
+ */
+void parseRestriction(List<RestrictionClause> restrictions) :
+{
+  Token restrictionProp;
+  List<String> values;
+}
+{
+  <RESTRICTION>
+  <LPAREN> restrictionProp=<NAMESPACED_ITEM> values=parseRestrictionValues()  <RPAREN>
+
+  {
+      restrictions.add(new RestrictionClause(restrictionProp.image,values));
+  }
+}
+
+/**
+ * parses list of restrictions
+ */
+List<RestrictionClause> parseRestrictions() :
+{
+    List<RestrictionClause> restrictions = new ArrayList<RestrictionClause>();
+}
+{
+   ( parseRestriction(restrictions) )*
+
+   {
+       return restrictions;
+   }
+}
 
 void pathPrivilegesLine(List<AclLine> lines) : 
 {
     AclLine line;
     List<String> tmp;
+    List<RestrictionClause> restrictions;
 }
 {
     line = privilegesLineOperation()
     tmp = namespacedItemsList() { line.setProperty(AclLine.PROP_PRIVILEGES, tmp); } 
     <ON> tmp = pathsList() { line.setProperty(AclLine.PROP_PATHS, tmp); }
     ( <NODETYPES> tmp = namespacedItemsList() { line.setProperty(AclLine.PROP_NODETYPES, tmp); }) ?
+     restrictions = parseRestrictions()  { line.setRestrictions(restrictions); }
     <EOL>
     
     {    

--- a/bundles/extensions/repoinit/parser/src/test/resources/testcases/test-10-output.txt
+++ b/bundles/extensions/repoinit/parser/src/test/resources/testcases/test-10-output.txt
@@ -3,3 +3,4 @@ SetAclPaths on /libs /apps / /content/example.com/some-other_path
   AclLine ALLOW {principals=[user1, user2], privileges=[jcr:read]}
   AclLine DENY {principals=[user2], privileges=[jcr:write, something:else, another:one]}
   AclLine DENY {principals=[user1], privileges=[jcr:lockManagement]}
+  AclLine DENY {principals=[user2], privileges=[jcr:modifyProperties]} restrictions=[rep:itemNames=[prop1, prop2]]

--- a/bundles/extensions/repoinit/parser/src/test/resources/testcases/test-10.txt
+++ b/bundles/extensions/repoinit/parser/src/test/resources/testcases/test-10.txt
@@ -7,4 +7,5 @@ set ACL on /libs,/apps, /, /content/example.com/some-other_path
 
     deny jcr:write,something:else,another:one for user2
     deny jcr:lockManagement for user1
+    deny jcr:modifyProperties for user2 restriction(rep:itemNames,prop1,prop2)
 end

--- a/bundles/extensions/repoinit/parser/src/test/resources/testcases/test-30-output.txt
+++ b/bundles/extensions/repoinit/parser/src/test/resources/testcases/test-30-output.txt
@@ -3,4 +3,10 @@ SetAclPrincipals for user1 u2
   AclLine ALLOW {paths=[/content], privileges=[jcr:read]}
   AclLine DENY {paths=[/apps], privileges=[jcr:write]}
   AclLine DENY {nodetypes=[sling:Folder, nt:unstructured], paths=[/apps, /content], privileges=[jcr:lockManagement]}
+  AclLine DENY {nodetypes=[sling:Folder, nt:unstructured], paths=[/apps, /content], privileges=[jcr:modifyProperties]} restrictions=[rep:itemNames=[prop1, prop2]]
   AclLine REMOVE {paths=[/apps], privileges=[jcr:understand, some:other]}
+  AclLine ALLOW {paths=[/apps], privileges=[jcr:addChildNodes]} restrictions=[rep:ntNames=[sling:Folder, nt:unstructured]]
+  AclLine ALLOW {paths=[/apps], privileges=[jcr:modifyProperties]} restrictions=[rep:ntNames=[sling:Folder, nt:unstructured], rep:itemNames=[prop1, prop2]]
+  AclLine ALLOW {paths=[/apps, /content], privileges=[jcr:addChildNodes]} restrictions=[rep:glob=[/cat, /cat/, cat]]
+  AclLine ALLOW {paths=[/apps, /content], privileges=[jcr:addChildNodes]} restrictions=[rep:glob=[cat/, *, *cat]]
+  AclLine ALLOW {paths=[/apps, /content], privileges=[jcr:addChildNodes]} restrictions=[rep:glob=[/cat/*, */cat, *cat/*]]

--- a/bundles/extensions/repoinit/parser/src/test/resources/testcases/test-30.txt
+++ b/bundles/extensions/repoinit/parser/src/test/resources/testcases/test-30.txt
@@ -6,7 +6,20 @@ set ACL for user1,u2
 
     deny jcr:write on /apps
     
-    # Optional nodetypes clause 
-    deny jcr:lockManagement on /apps, /content nodetypes sling:Folder, nt:unstructured   
+    # Optional nodetypes clause
+    deny jcr:lockManagement on /apps, /content nodetypes sling:Folder, nt:unstructured
+    # nodetypes clause with restriction clause
+    deny jcr:modifyProperties on /apps, /content nodetypes sling:Folder, nt:unstructured restriction(rep:itemNames,prop1,prop2)
     remove jcr:understand,some:other on /apps
+
+    # multi value restriction
+    allow jcr:addChildNodes on /apps restriction(rep:ntNames,sling:Folder,nt:unstructured)
+
+    # multiple restrictions
+    allow jcr:modifyProperties on /apps restriction(rep:ntNames,sling:Folder,nt:unstructured) restriction(rep:itemNames,prop1,prop2)
+
+    # restrictions with glob patterns
+    allow jcr:addChildNodes on /apps,/content restriction(rep:glob,/cat,/cat/,cat)
+    allow jcr:addChildNodes on /apps,/content restriction(rep:glob,cat/,*,*cat)
+    allow jcr:addChildNodes on /apps,/content restriction(rep:glob,/cat/*,*/cat,*cat/*)
 end


### PR DESCRIPTION
   - Add support for restriction clause in parser
   - example acl with restriction spec
     - set ACL on /libs
         deny jcr:modifyProperties for user2 restriction(rep:itemNames,prop1,prop2)
       end
     - set ACL for user1,u2
         allow jcr:addChildNodes on /apps,/content restriction(rep:glob,/cat/*,*/cat,*cat/*)
       end