### PR TITLE
SLING-6428 - DateFormat is printed when date-value is empty

### DIFF
--- a/bundles/scripting/sightly/engine/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/FormatFilterExtension.java
+++ b/bundles/scripting/sightly/engine/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/FormatFilterExtension.java
@@ -110,6 +110,9 @@ public class FormatFilterExtension implements RuntimeExtension {
     }
 
     private Object[] decodeParams(RuntimeObjectModel runtimeObjectModel, Object paramObj) {
+        if (paramObj == null) {
+            return null;
+        }
         if (runtimeObjectModel.isCollection(paramObj)) {
             return runtimeObjectModel.toCollection(paramObj).toArray();
         }
@@ -117,6 +120,9 @@ public class FormatFilterExtension implements RuntimeExtension {
     }
 
     private String formatString(RuntimeObjectModel runtimeObjectModel, String source, Object[] params) {
+        if (params == null) {
+            return null;
+        }
         Matcher matcher = PLACEHOLDER_REGEX.matcher(source);
         StringBuilder builder = new StringBuilder();
         int lastPos = 0;
@@ -145,6 +151,9 @@ public class FormatFilterExtension implements RuntimeExtension {
     }
 
     private String formatDate(String format, Date date, Locale locale, TimeZone timezone) {
+        if (date == null) {
+            return null;
+        }
         try {
             SimpleDateFormat formatter;
             if (locale != null) {
@@ -163,6 +172,9 @@ public class FormatFilterExtension implements RuntimeExtension {
     }
 
     private String formatNumber(String format, Number number, Locale locale) {
+        if (number == null) {
+            return null;
+        }
         try {
             NumberFormat formatter;
             if (locale != null) {

--- a/bundles/scripting/sightly/java-compiler/src/main/java/org/apache/sling/scripting/sightly/render/AbstractRuntimeObjectModel.java
+++ b/bundles/scripting/sightly/java-compiler/src/main/java/org/apache/sling/scripting/sightly/render/AbstractRuntimeObjectModel.java
@@ -104,7 +104,7 @@ public abstract class AbstractRuntimeObjectModel implements RuntimeObjectModel {
         if (object instanceof Number) {
             return (Number) object;
         }
-        return 0;
+        return null;
     }
 
     public Date toDate(Object object) {
@@ -113,7 +113,7 @@ public abstract class AbstractRuntimeObjectModel implements RuntimeObjectModel {
         } else if (object instanceof Calendar) {
             return ((Calendar)object).getTime();
         }
-        return new Date(0);
+        return null;
     }
 
     @Override

--- a/bundles/scripting/sightly/java-compiler/src/main/java/org/apache/sling/scripting/sightly/render/RuntimeObjectModel.java
+++ b/bundles/scripting/sightly/java-compiler/src/main/java/org/apache/sling/scripting/sightly/render/RuntimeObjectModel.java
@@ -45,8 +45,20 @@ public interface RuntimeObjectModel {
      */
     boolean isCollection(Object target);
 
+    /**
+     * Checks if the provided object represents a number or not.
+     *
+     * @param target the target object
+     * @return {@code true} if the {@code target} is a number, {@code false} otherwise
+     */
     boolean isNumber(Object target);
 
+    /**
+     * Checks if the provided object represents a date or calendar.
+     *
+     * @param target the target object
+     * @return {@code true} if the {@code target} is a date or calendar, {@code false} otherwise
+     */
     boolean isDate(Object target);
 
     /**
@@ -75,6 +87,12 @@ public interface RuntimeObjectModel {
      */
     Number toNumber(Object object);
 
+    /**
+     * Convert the given object to a {@link Date} object
+     *
+     * @param object the target object
+     * @return the date represented by the {@code object}
+     */
     Date toDate(Object object);
 
     /**

--- a/bundles/scripting/sightly/testing-content/pom.xml
+++ b/bundles/scripting/sightly/testing-content/pom.xml
@@ -100,7 +100,7 @@
                                 <artifactItem>
                                     <groupId>io.sightly</groupId>
                                     <artifactId>io.sightly.tck</artifactId>
-                                    <version>1.3.0</version>
+                                    <version>1.3.1-SNAPSHOT</version>
                                     <type>jar</type>
                                     <outputDirectory>${project.build.directory}/sightlytck/</outputDirectory>
                                     <includes>**/*.html,**/*.js,**/*.java</includes>

--- a/bundles/scripting/sightly/testing/pom.xml
+++ b/bundles/scripting/sightly/testing/pom.xml
@@ -392,7 +392,7 @@
         <dependency>
             <groupId>io.sightly</groupId>
             <artifactId>io.sightly.tck</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.1-SNAPSHOT</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
* Updated TCK to include tests for empty/undefined formatting input values
* Updated implementation to return empty when formatting input is null/undefined
* Added missing javadocs