### PR TITLE
SLING-6482: Fix Exception in Commons Log WebConsole

### DIFF
--- a/bundles/commons/log/src/main/java/org/apache/sling/commons/log/logback/internal/SlingLogPanel.java
+++ b/bundles/commons/log/src/main/java/org/apache/sling/commons/log/logback/internal/SlingLogPanel.java
@@ -785,7 +785,7 @@ public class SlingLogPanel implements LogPanel {
     }
 
     private static String getPath(String path, final String rootPath, final boolean shortenPaths) {
-        if (shortenPaths && path != null) {
+        if (shortenPaths && path != null && path.length() > rootPath.length()) {
             // if the shortenPath parameter is set (all log files are in the same folder)
             // remove the root path (root log file folder) from the paths
             path = path.substring(rootPath.length() + 1);


### PR DESCRIPTION
SLING-6482: Fix StringIndexOutOfBoundsException in Commons Log WebConsole by adding a length check for the path. 
https://issues.apache.org/jira/browse/SLING-6482