### PR TITLE
SLING-6538: Fix Sling Pipes size parameter

### DIFF
--- a/contrib/extensions/sling-pipes/src/main/java/org/apache/sling/pipes/internal/PlumberServlet.java
+++ b/contrib/extensions/sling-pipes/src/main/java/org/apache/sling/pipes/internal/PlumberServlet.java
@@ -121,7 +121,7 @@ public class PlumberServlet extends SlingAllMethodsServlet {
             while (resourceIterator.hasNext()){
                 Resource resource = resourceIterator.next();
                 paths.add(resource.getPath());
-                if (++i < size) {
+                if (i++ < size) {
                     writer.writeItem(resource);
                 }
             }


### PR DESCRIPTION
Make Sling Pipes size parameter return the correct number of items. Add tests for
the size parameter in the PlumberServletTest.