### PR TITLE
Feature/sling 6652

### DIFF
--- a/bundles/extensions/models/api/src/main/java/org/apache/sling/models/factory/ModelFactory.java
+++ b/bundles/extensions/models/api/src/main/java/org/apache/sling/models/factory/ModelFactory.java
@@ -50,7 +50,6 @@ public interface ModelFactory {
             InvalidAdaptableException, ModelClassException, PostConstructException, ValidationException, InvalidModelException;
 
     /**
-     *
      * @param adaptable the adaptable to check
      * @param type the class to check
      * @return {@code true} in case the given class can be created from the given adaptable, otherwise {@code false}
@@ -58,7 +57,6 @@ public interface ModelFactory {
     public boolean canCreateFromAdaptable(@Nonnull Object adaptable, @Nonnull Class<?> type);
 
     /**
-     *
      * @param adaptable the adaptable to check
      * @param type the class to check
      * @return false in case no class with the Model annotation adapts to the requested type
@@ -78,7 +76,6 @@ public interface ModelFactory {
      * Only if both conditions are fulfilled this method will return {@code true}.
      * @param type the class to check
      * @return {@code true} in case the given type can be instantiated though Sling Models.
-     *
      */
     public boolean isModelClass(@Nonnull Class<?> type);
 

--- a/bundles/extensions/models/api/src/main/java/org/apache/sling/models/factory/ModelFactory.java
+++ b/bundles/extensions/models/api/src/main/java/org/apache/sling/models/factory/ModelFactory.java
@@ -50,7 +50,7 @@ public interface ModelFactory {
             InvalidAdaptableException, ModelClassException, PostConstructException, ValidationException, InvalidModelException;
 
     /**
-     * 
+     *
      * @param adaptable the adaptable to check
      * @param type the class to check
      * @return {@code true} in case the given class can be created from the given adaptable, otherwise {@code false}
@@ -58,11 +58,11 @@ public interface ModelFactory {
     public boolean canCreateFromAdaptable(@Nonnull Object adaptable, @Nonnull Class<?> type);
 
     /**
-     * 
+     *
      * @param adaptable the adaptable to check
      * @param type the class to check
      * @return false in case no class with the Model annotation adapts to the requested type
-     * 
+     *
      * @see org.apache.sling.models.annotations.Model
      * @deprecated Use {@link #isModelClass(Class)} instead!
      */
@@ -77,8 +77,8 @@ public interface ModelFactory {
      * </ul>
      * Only if both conditions are fulfilled this method will return {@code true}.
      * @param type the class to check
-     * @return {@code true} in case the given type can be instantiated though Sling Models. 
-     * 
+     * @return {@code true} in case the given type can be instantiated though Sling Models.
+     *
      */
     public boolean isModelClass(@Nonnull Class<?> type);
 
@@ -99,7 +99,8 @@ public interface ModelFactory {
     public boolean isModelAvailableForRequest(@Nonnull SlingHttpServletRequest request);
 
     /**
-     * Obtain an adapted model class based on the resource type of the provided resource.
+     * Obtain an adapted model class based on the resource type of the provided resource. If multiple adapter implementations are registered
+     * for the resource's resourceType the first one in alphabetical order will be used.
      *
      * @param resource a resource
      * @return an adapted model object
@@ -110,11 +111,31 @@ public interface ModelFactory {
      * @throws ValidationException in case validation could not be performed for some reason (e.g. no validation information available)
      * @throws InvalidModelException in case the given model type could not be validated through the model validation
      */
+    @Deprecated
     public Object getModelFromResource(@Nonnull Resource resource) throws MissingElementsException,
             InvalidAdaptableException, ModelClassException, PostConstructException, ValidationException, InvalidModelException;
 
+
     /**
-     * Obtain an adapted model class based on the resource type of the request's resource.
+     * Obtain an adapted model class based on the resource type of the provided resource, only if the the given adapterType is registered
+     * with that resourceType.
+     *
+     * @param resource a resource
+     * @param adapterType the adapterType to return the model for if registered for the resourceType
+     * @return an adapted model object
+     * @throws MissingElementsException in case no injector was able to inject some required values with the given types
+     * @throws InvalidAdaptableException in case the given class cannot be instantiated from the given adaptable (different adaptable on the model annotation)
+     * @throws ModelClassException in case the model could not be instantiated because model annotation was missing, reflection failed, no valid constructor was found, model was not registered as adapter factory yet, or post-construct could not be called
+     * @throws PostConstructException in case the post-construct method has thrown an exception itself
+     * @throws ValidationException in case validation could not be performed for some reason (e.g. no validation information available)
+     * @throws InvalidModelException in case the given model type could not be validated through the model validation
+     */
+    public <ModelType> ModelType getModelFromResource(@Nonnull Resource resource, Class<ModelType> adapterType) throws MissingElementsException,
+            InvalidAdaptableException, ModelClassException, PostConstructException, ValidationException, InvalidModelException;
+
+    /**
+     * Obtain an adapted model class based on the resource type of the request's resource. If multiple adapter implementations are
+     * registered for the request's resource's resourceType the first one in alphabetical order will be used.
      *
      * @param request a request
      * @return an adapted model object
@@ -125,7 +146,25 @@ public interface ModelFactory {
      * @throws ValidationException in case validation could not be performed for some reason (e.g. no validation information available)
      * @throws InvalidModelException in case the given model type could not be validated through the model validation
      */
+    @Deprecated
     public Object getModelFromRequest(@Nonnull SlingHttpServletRequest request) throws MissingElementsException,
+            InvalidAdaptableException, ModelClassException, PostConstructException, ValidationException, InvalidModelException;
+
+    /**
+     * Obtain an adapted model class based on the resource type of the request's resource, only if the the given adapterType is registered
+     * with that resourceType.
+     *
+     * @param request a request
+     * @param adapterType the adapterType to return the model for if registered for the resourceType
+     * @return an adapted model object
+     * @throws MissingElementsException in case no injector was able to inject some required values with the given types
+     * @throws InvalidAdaptableException in case the given class cannot be instantiated from the given adaptable (different adaptable on the model annotation)
+     * @throws ModelClassException in case the model could not be instantiated because model annotation was missing, reflection failed, no valid constructor was found, model was not registered as adapter factory yet, or post-construct could not be called
+     * @throws PostConstructException in case the post-construct method has thrown an exception itself
+     * @throws ValidationException in case validation could not be performed for some reason (e.g. no validation information available)
+     * @throws InvalidModelException in case the given model type could not be validated through the model validation
+     */
+    public <ModelType> ModelType getModelFromRequest(@Nonnull SlingHttpServletRequest request, Class<ModelType> adapterType) throws MissingElementsException,
             InvalidAdaptableException, ModelClassException, PostConstructException, ValidationException, InvalidModelException;
 
     /**
@@ -160,7 +199,32 @@ public interface ModelFactory {
      * @throws ExportException if the export fails
      * @throws MissingExporterException if the named exporter can't be found
      */
+    @Deprecated
     public <T> T exportModelForResource(Resource resource, String exporterName, Class<T> targetClass, Map<String, String> options) throws MissingElementsException,
+            InvalidAdaptableException, ModelClassException, PostConstructException, ValidationException, InvalidModelException,
+            ExportException, MissingExporterException;
+
+    /**
+     * Export the model object registered to the resource's type using the defined target class using the named exporter and using the given
+     * adapterType for retrieving the model.
+     *
+     * @param resource the resource
+     * @param exporterName the exporter name
+     * @param targetClass the target class
+     * @param usingAdapterType the adapterType used to get the model from the resource
+     * @param options any exporter options
+     * @param <T> the target class
+     * @return an instance of the target class
+     * @throws MissingElementsException in case no injector was able to inject some required values with the given types
+     * @throws InvalidAdaptableException in case the given class cannot be instantiated from the given adaptable (different adaptable on the model annotation)
+     * @throws ModelClassException in case the model could not be instantiated because model annotation was missing, reflection failed, no valid constructor was found, model was not registered as adapter factory yet, or post-construct could not be called
+     * @throws PostConstructException in case the post-construct method has thrown an exception itself
+     * @throws ValidationException in case validation could not be performed for some reason (e.g. no validation information available)
+     * @throws InvalidModelException in case the given model type could not be validated through the model validation
+     * @throws ExportException if the export fails
+     * @throws MissingExporterException if the named exporter can't be found
+     */
+    public <T, ModelType> T exportModelForResource(Resource resource, String exporterName, Class<T> targetClass, Class<ModelType> usingAdapterType, Map<String, String> options) throws MissingElementsException,
             InvalidAdaptableException, ModelClassException, PostConstructException, ValidationException, InvalidModelException,
             ExportException, MissingExporterException;
 
@@ -182,7 +246,32 @@ public interface ModelFactory {
      * @throws ExportException if the export fails
      * @throws MissingExporterException if the named exporter can't be found
      */
-    public <T> T exportModelForRequest(SlingHttpServletRequest request, String exporterName, Class<T> targetClass, Map<String, String> options) throws MissingElementsException,
+    @Deprecated
+    public <T, ModelType> T exportModelForRequest(SlingHttpServletRequest request, String exporterName, Class<T> targetClass, Map<String, String> options) throws MissingElementsException,
+            InvalidAdaptableException, ModelClassException, PostConstructException, ValidationException, InvalidModelException,
+            ExportException, MissingExporterException;
+
+    /**
+     * Export the model object registered to the request's resource's type using the defined target class using the named exporter and using
+     * the given adapterType for retrieving the model.
+     *
+     * @param request the request
+     * @param exporterName the exporter name
+     * @param targetClass the target class
+     * @param usingAdapterType the adapterType used to get the model from the resource
+     * @param options any exporter options
+     * @param <T> the target class
+     * @return an instance of the target class
+     * @throws MissingElementsException in case no injector was able to inject some required values with the given types
+     * @throws InvalidAdaptableException in case the given class cannot be instantiated from the given adaptable (different adaptable on the model annotation)
+     * @throws ModelClassException in case the model could not be instantiated because model annotation was missing, reflection failed, no valid constructor was found, model was not registered as adapter factory yet, or post-construct could not be called
+     * @throws PostConstructException in case the post-construct method has thrown an exception itself
+     * @throws ValidationException in case validation could not be performed for some reason (e.g. no validation information available)
+     * @throws InvalidModelException in case the given model type could not be validated through the model validation
+     * @throws ExportException if the export fails
+     * @throws MissingExporterException if the named exporter can't be found
+     */
+    public <T, ModelType> T exportModelForRequest(SlingHttpServletRequest request, String exporterName, Class<T> targetClass, Class<ModelType> usingAdapterType, Map<String, String> options) throws MissingElementsException,
             InvalidAdaptableException, ModelClassException, PostConstructException, ValidationException, InvalidModelException,
             ExportException, MissingExporterException;
 

--- a/bundles/extensions/models/api/src/main/java/org/apache/sling/models/factory/ModelFactory.java
+++ b/bundles/extensions/models/api/src/main/java/org/apache/sling/models/factory/ModelFactory.java
@@ -50,6 +50,7 @@ public interface ModelFactory {
             InvalidAdaptableException, ModelClassException, PostConstructException, ValidationException, InvalidModelException;
 
     /**
+     *
      * @param adaptable the adaptable to check
      * @param type the class to check
      * @return {@code true} in case the given class can be created from the given adaptable, otherwise {@code false}
@@ -57,6 +58,7 @@ public interface ModelFactory {
     public boolean canCreateFromAdaptable(@Nonnull Object adaptable, @Nonnull Class<?> type);
 
     /**
+     *
      * @param adaptable the adaptable to check
      * @param type the class to check
      * @return false in case no class with the Model annotation adapts to the requested type
@@ -76,6 +78,7 @@ public interface ModelFactory {
      * Only if both conditions are fulfilled this method will return {@code true}.
      * @param type the class to check
      * @return {@code true} in case the given type can be instantiated though Sling Models.
+     *
      */
     public boolean isModelClass(@Nonnull Class<?> type);
 

--- a/bundles/extensions/models/api/src/main/java/org/apache/sling/models/factory/package-info.java
+++ b/bundles/extensions/models/api/src/main/java/org/apache/sling/models/factory/package-info.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@Version("1.3.1")
+@Version("1.4.0")
 package org.apache.sling.models.factory;
 
 import aQute.bnd.annotation.Version;

--- a/bundles/extensions/models/impl/pom.xml
+++ b/bundles/extensions/models/impl/pom.xml
@@ -125,7 +125,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.models.api</artifactId>
-            <version>1.3.2</version>
+            <version>1.3.3-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/bundles/extensions/models/impl/src/main/java/org/apache/sling/models/impl/AdapterImplementations.java
+++ b/bundles/extensions/models/impl/src/main/java/org/apache/sling/models/impl/AdapterImplementations.java
@@ -48,18 +48,22 @@ import org.slf4j.LoggerFactory;
  */
 final class AdapterImplementations {
 
+    // TODO: logging
     private static final Logger log = LoggerFactory.getLogger(AdapterImplementations.class);
 
-    private final ConcurrentMap<String,ConcurrentNavigableMap<String,ModelClass<?>>> adapterImplementations
-            = new ConcurrentHashMap<String,ConcurrentNavigableMap<String,ModelClass<?>>>();
+    // Map<full qualified adapter type, Map<full qualified implementation type, ModelClass of implementation type>>
+    private final ConcurrentMap<String, ConcurrentNavigableMap<String, ModelClass<?>>> adapterImplementations
+            = new ConcurrentHashMap<String, ConcurrentNavigableMap<String, ModelClass<?>>>();
 
-    private final ConcurrentMap<String,ModelClass<?>> modelClasses
-            = new ConcurrentHashMap<String,ModelClass<?>>();
-    
-    private final ConcurrentMap<String, Class<?>> resourceTypeMappingsForResources = new ConcurrentHashMap<String, Class<?>>();
-    private final ConcurrentMap<String, Class<?>> resourceTypeMappingsForRequests = new ConcurrentHashMap<String, Class<?>>();
-    private final ConcurrentMap<Bundle, List<String>> resourceTypeRemovalListsForResources = new ConcurrentHashMap<Bundle, List<String>>();
-    private final ConcurrentMap<Bundle, List<String>> resourceTypeRemovalListsForRequests = new ConcurrentHashMap<Bundle, List<String>>();
+    private final ConcurrentMap<String, ModelClass<?>> modelClasses
+            = new ConcurrentHashMap<String, ModelClass<?>>();
+
+    // Map<resourceType, Map<full qualified implementation type, implementation type>>
+    private final ConcurrentMap<String, ConcurrentNavigableMap<String, Class<?>>> resourceTypeMappingsForResources = new ConcurrentHashMap<String, ConcurrentNavigableMap<String, Class<?>>>();
+    private final ConcurrentMap<String, ConcurrentNavigableMap<String, Class<?>>> resourceTypeMappingsForRequests = new ConcurrentHashMap<String, ConcurrentNavigableMap<String, Class<?>>>();
+    // Map<Bundle, Map<resourceType, List of implementation types of the bundle>>
+    private final ConcurrentMap<Bundle, ConcurrentMap<String, List<Class<?>>>> resourceTypeRemovalListsForResources = new ConcurrentHashMap<Bundle, ConcurrentMap<String, List<Class<?>>>>();
+    private final ConcurrentMap<Bundle, ConcurrentMap<String, List<Class<?>>>> resourceTypeRemovalListsForRequests = new ConcurrentHashMap<Bundle, ConcurrentMap<String, List<Class<?>>>>();
 
     private volatile ImplementationPicker[] sortedImplementationPickers = new ImplementationPicker[0];
     private volatile StaticInjectAnnotationProcessorFactory[] sortedStaticInjectAnnotationProcessorFactories = new StaticInjectAnnotationProcessorFactory[0];
@@ -71,38 +75,42 @@ final class AdapterImplementations {
     public ImplementationPicker[] getImplementationPickers() {
         return this.sortedImplementationPickers;
     }
-    
+
     public StaticInjectAnnotationProcessorFactory[] getStaticInjectAnnotationProcessorFactories() {
         return sortedStaticInjectAnnotationProcessorFactories;
     }
 
     public void setStaticInjectAnnotationProcessorFactories(
             Collection<StaticInjectAnnotationProcessorFactory> factories) {
-        this.sortedStaticInjectAnnotationProcessorFactories = factories.toArray(new StaticInjectAnnotationProcessorFactory[factories.size()]);
+        this.sortedStaticInjectAnnotationProcessorFactories = factories
+                .toArray(new StaticInjectAnnotationProcessorFactory[factories.size()]);
         updateProcessorFactoriesInModelClasses();
     }
-    
+
     /**
      * Updates all {@link ModelClass} instances with updates list of static inject annotation processor factories.
      */
     private void updateProcessorFactoriesInModelClasses() {
         Iterator<ModelClass<?>> items = modelClasses.values().iterator();
-        updateProcessorFactoriesInModelClasses(items);        
-        Iterator<ConcurrentNavigableMap<String,ModelClass<?>>> mapItems = adapterImplementations.values().iterator();
+        updateProcessorFactoriesInModelClasses(items);
+        Iterator<ConcurrentNavigableMap<String, ModelClass<?>>> mapItems = adapterImplementations.values().iterator();
         while (mapItems.hasNext()) {
-            ConcurrentNavigableMap<String,ModelClass<?>> mapItem = mapItems.next();
+            ConcurrentNavigableMap<String, ModelClass<?>> mapItem = mapItems.next();
             updateProcessorFactoriesInModelClasses(mapItem.values().iterator());
         }
     }
+
     private void updateProcessorFactoriesInModelClasses(Iterator<ModelClass<?>> items) {
         while (items.hasNext()) {
             ModelClass<?> item = items.next();
             item.updateProcessorFactories(sortedStaticInjectAnnotationProcessorFactories);
         }
     }
-    
-    /** Add implementation mapping for the given model class (implementation is the model class itself).
+
+    /**
+     * Add implementation mapping for the given model class (implementation is the model class itself).
      * Only used for testing purposes. Use {@link #add(Class, Class)} in case you want to register a different implementation.
+     *
      * @param modelClasses the model classes to register
      */
     protected void addClassesAsAdapterAndImplementation(Class<?>... modelClasses) {
@@ -110,46 +118,46 @@ final class AdapterImplementations {
             add(modelClass, modelClass);
         }
     }
-    
+
     /**
      * Add implementation mapping for the given adapter type.
+     *
      * @param adapterType Adapter type
-     * @param implType Implementation type
+     * @param implType    Implementation type
      */
     @SuppressWarnings("unchecked")
     public void add(Class<?> adapterType, Class<?> implType) {
         String key = adapterType.getName();
         if (adapterType == implType) {
             modelClasses.put(key, new ModelClass(implType, sortedStaticInjectAnnotationProcessorFactories));
-        }
-        else {
+        } else {
             // although we already use a ConcurrentMap synchronize explicitly because we apply non-atomic operations on it
             synchronized (adapterImplementations) {
-                ConcurrentNavigableMap<String,ModelClass<?>> implementations = adapterImplementations.get(key);
+                ConcurrentNavigableMap<String, ModelClass<?>> implementations = adapterImplementations.get(key);
                 if (implementations == null) {
                     // to have a consistent ordering independent of bundle loading use a ConcurrentSkipListMap that sorts by class name
-                    implementations = new ConcurrentSkipListMap<String,ModelClass<?>>();
+                    implementations = new ConcurrentSkipListMap<String, ModelClass<?>>();
                     adapterImplementations.put(key, implementations);
                 }
                 implementations.put(implType.getName(), new ModelClass(implType, sortedStaticInjectAnnotationProcessorFactories));
             }
         }
     }
-    
+
     /**
      * Remove implementation mapping for the given adapter type.
+     *
      * @param adapterTypeName Adapter type name
-     * @param implTypeName Implementation type name
+     * @param implTypeName    Implementation type name
      */
     public void remove(String adapterTypeName, String implTypeName) {
         String key = adapterTypeName;
         if (StringUtils.equals(adapterTypeName, implTypeName)) {
             modelClasses.remove(key);
-        }
-        else {
+        } else {
             // although we already use a ConcurrentMap synchronize explicitly because we apply non-atomic operations on it
             synchronized (adapterImplementations) {
-                ConcurrentNavigableMap<String,ModelClass<?>> implementations = adapterImplementations.get(key);
+                ConcurrentNavigableMap<String, ModelClass<?>> implementations = adapterImplementations.get(key);
                 if (implementations != null) {
                     implementations.remove(implTypeName);
                     if (implementations.isEmpty()) {
@@ -170,40 +178,42 @@ final class AdapterImplementations {
 
     /**
      * Lookup the best-matching implementation for the given adapter type by enquiring the {@link ImplementationPicker} services.
+     *
      * @param adapterType Adapter type
-     * @param adaptable Adaptable for reference
+     * @param adaptable   Adaptable for reference
      * @return Implementation type or null if none detected
      */
     @SuppressWarnings("unchecked")
     public <ModelType> ModelClass<ModelType> lookup(Class<ModelType> adapterType, Object adaptable) {
         String key = adapterType.getName();
-        
+
         // lookup in cache for models without adapter classes
-        ModelClass<ModelType> modelClass = (ModelClass<ModelType>)modelClasses.get(key);
-        if (modelClass!=null) {
+        ModelClass<ModelType> modelClass = (ModelClass<ModelType>) modelClasses.get(key);
+        if (modelClass != null) {
             return modelClass;
         }
 
         // not found? look in cache with adapter classes
-        ConcurrentNavigableMap<String,ModelClass<?>> implementations = adapterImplementations.get(key);
-        if (implementations==null || implementations.isEmpty()) {
+        ConcurrentNavigableMap<String, ModelClass<?>> implementations = adapterImplementations.get(key);
+        if (implementations == null || implementations.isEmpty()) {
             return null;
         }
         Collection<ModelClass<?>> implementationsCollection = implementations.values();
-        ModelClass<?>[] implementationWrappersArray = implementationsCollection.toArray(new ModelClass<?>[implementationsCollection.size()]);
-        
+        ModelClass<?>[] implementationWrappersArray = implementationsCollection
+                .toArray(new ModelClass<?>[implementationsCollection.size()]);
+
         // prepare array for implementation picker
         Class<?>[] implementationsArray = new Class<?>[implementationsCollection.size()];
-        for (int i=0; i<implementationWrappersArray.length; i++) {
+        for (int i = 0; i < implementationWrappersArray.length; i++) {
             implementationsArray[i] = implementationWrappersArray[i].getType();
         }
 
         for (ImplementationPicker picker : this.sortedImplementationPickers) {
             Class<?> implementation = picker.pick(adapterType, implementationsArray, adaptable);
             if (implementation != null) {
-                for (int i=0; i<implementationWrappersArray.length; i++) {
-                    if (implementation==implementationWrappersArray[i].getType()) {
-                        return (ModelClass<ModelType>)implementationWrappersArray[i];
+                for (int i = 0; i < implementationWrappersArray.length; i++) {
+                    if (implementation == implementationWrappersArray[i].getType()) {
+                        return (ModelClass<ModelType>) implementationWrappersArray[i];
                     }
                 }
             }
@@ -219,123 +229,145 @@ final class AdapterImplementations {
     @SuppressWarnings("unchecked")
     public <ModelType> boolean isModelClass(Class<ModelType> adapterType) {
         String key = adapterType.getName();
-        
+
         // lookup in cache for models without adapter classes
-        ModelClass<ModelType> modelClass = (ModelClass<ModelType>)modelClasses.get(key);
-        if (modelClass!=null) {
+        ModelClass<ModelType> modelClass = (ModelClass<ModelType>) modelClasses.get(key);
+        if (modelClass != null) {
             return true;
         }
 
         // not found? look in cache with adapter classes
-        ConcurrentNavigableMap<String,ModelClass<?>> implementations = adapterImplementations.get(key);
-        if (implementations==null || implementations.isEmpty()) {
+        ConcurrentNavigableMap<String, ModelClass<?>> implementations = adapterImplementations.get(key);
+        if (implementations == null || implementations.isEmpty()) {
             return false;
         }
         return true;
     }
 
-     public void registerModelToResourceType(final Bundle bundle, final String resourceType, final Class<?> adaptableType, final Class<?> clazz) {
-         if (resourceType.startsWith("/")) {
-             log.warn("Registering model class {} for adaptable {} with absolute resourceType {}." ,
-                     new Object[] { clazz, adaptableType, resourceType });
-         }
-         ConcurrentMap<String, Class<?>> map;
-         ConcurrentMap<Bundle, List<String>> resourceTypeRemovalLists;
-         if (adaptableType == Resource.class) {
-             map = resourceTypeMappingsForResources;
-             resourceTypeRemovalLists = resourceTypeRemovalListsForResources;
-         } else if (adaptableType == SlingHttpServletRequest.class) {
-             map = resourceTypeMappingsForRequests;
-             resourceTypeRemovalLists = resourceTypeRemovalListsForRequests;
-         } else {
-             log.warn("Found model class {} with resource type {} for adaptable {}. Unsupported type for resourceType binding.",
-                     new Object[] { clazz, resourceType, adaptableType });
-             return;
-         }
-         Class<?> existingMapping = map.putIfAbsent(resourceType, clazz);
-         if (existingMapping == null) {
-             resourceTypeRemovalLists.putIfAbsent(bundle, new CopyOnWriteArrayList<String>());
-             resourceTypeRemovalLists.get(bundle).add(resourceType);
-         } else {
-             log.warn("Skipped registering {} for resourceType {} under adaptable {} because of existing mapping to {}",
-                     new Object[] { clazz, resourceType, adaptableType, existingMapping });
-         }
-     }
-
-     public void removeResourceTypeBindings(final Bundle bundle) {
-         List<String> registeredResourceTypes = resourceTypeRemovalListsForResources.remove(bundle);
-         if (registeredResourceTypes != null) {
-             for (String resourceType : registeredResourceTypes) {
-                 resourceTypeMappingsForResources.remove(resourceType);
-             }
-         }
-         registeredResourceTypes = resourceTypeRemovalListsForRequests.remove(bundle);
-         if (registeredResourceTypes != null) {
-             for (String resourceType : registeredResourceTypes) {
-                 resourceTypeMappingsForRequests.remove(resourceType);
-             }
-         }
-     }
-
-     public Class<?> getModelClassForRequest(final SlingHttpServletRequest request) {
-         return getModelClassForResource(request.getResource(), resourceTypeMappingsForRequests);
-     }
-
-    public Class<?> getModelClassForResource(final Resource resource) {
-        return getModelClassForResource(resource, resourceTypeMappingsForResources);
+    public void registerModelToResourceType(final Bundle bundle, final String resourceType, final Class<?> adaptableType,
+            final Class<?> clazz) {
+        if (resourceType.startsWith("/")) {
+            log.warn("Registering model class {} for adaptable {} with absolute resourceType {}.",
+                    new Object[] { clazz, adaptableType, resourceType });
+        }
+        ConcurrentMap<String, ConcurrentNavigableMap<String, Class<?>>> map;
+        ConcurrentMap<Bundle, ConcurrentMap<String, List<Class<?>>>> resourceTypeRemovalLists;
+        if (adaptableType == Resource.class) {
+            map = resourceTypeMappingsForResources;
+            resourceTypeRemovalLists = resourceTypeRemovalListsForResources;
+        } else if (adaptableType == SlingHttpServletRequest.class) {
+            map = resourceTypeMappingsForRequests;
+            resourceTypeRemovalLists = resourceTypeRemovalListsForRequests;
+        } else {
+            log.warn("Found model class {} with resource type {} for adaptable {}. Unsupported type for resourceType binding.",
+                    new Object[] { clazz, resourceType, adaptableType });
+            return;
+        }
+        map.putIfAbsent(resourceType, new ConcurrentSkipListMap<String, Class<?>>());
+        map.get(resourceType).put(clazz.getName(), clazz);
+        resourceTypeRemovalLists.putIfAbsent(bundle, new ConcurrentHashMap<String, List<Class<?>>>());
+        resourceTypeRemovalLists.get(bundle).putIfAbsent(resourceType, new CopyOnWriteArrayList<Class<?>>());
+        resourceTypeRemovalLists.get(bundle).get(resourceType).add(clazz);
     }
 
-    protected static Class<?> getModelClassForResource(final Resource resource, final Map<String, Class<?>> map) {
+    public void removeResourceTypeBindings(final Bundle bundle) {
+        Map<String, List<Class<?>>> registeredResourceTypes = resourceTypeRemovalListsForResources.remove(bundle);
+        if (registeredResourceTypes != null) {
+            for (Map.Entry<String, List<Class<?>>> entry : registeredResourceTypes.entrySet()) {
+                for (Class<?> clazz : entry.getValue()) {
+                    resourceTypeMappingsForResources.get(entry.getKey()).remove(clazz.getName());
+                }
+            }
+        }
+        registeredResourceTypes = resourceTypeRemovalListsForRequests.remove(bundle);
+        if (registeredResourceTypes != null) {
+            for (Map.Entry<String, List<Class<?>>> entry : registeredResourceTypes.entrySet()) {
+                for (Class<?> clazz : entry.getValue()) {
+                    resourceTypeMappingsForRequests.get(entry.getKey()).remove(clazz.getName());
+                }
+            }
+        }
+    }
+
+    @Deprecated
+    public Class<?> getModelClassForRequest(final SlingHttpServletRequest request) {
+        return getModelClassForRequest(request, null);
+    }
+
+    public <ModelType> Class<ModelType> getModelClassForRequest(final SlingHttpServletRequest request, Class<ModelType> adapterType) {
+        return getModelClassForResource(request.getResource(), resourceTypeMappingsForRequests, adapterType);
+    }
+
+    @Deprecated
+    public Class<?> getModelClassForResource(final Resource resource) {
+        return getModelClassForResource(resource, null);
+    }
+
+    public <ModelType> Class<ModelType> getModelClassForResource(final Resource resource, Class<ModelType> adapterType) {
+        return getModelClassForResource(resource, resourceTypeMappingsForResources, adapterType);
+    }
+
+    protected static <ModelType> Class<ModelType> getModelClassForResource(final Resource resource,
+            final Map<String, ConcurrentNavigableMap<String, Class<?>>> map, Class<ModelType> adapterType) {
         if (resource == null) {
             return null;
         }
         ResourceResolver resolver = resource.getResourceResolver();
         final String originalResourceType = resource.getResourceType();
-        Class<?> modelClass = getClassFromResourceTypeMap(originalResourceType, map, resolver);
+        Class<?> modelClass = getClassFromResourceTypeMap(originalResourceType, map, resolver, adapterType);
         if (modelClass != null) {
-            return modelClass;
+            return (Class<ModelType>) modelClass;
         } else {
             String resourceType = resolver.getParentResourceType(resource);
             while (resourceType != null) {
-                modelClass = getClassFromResourceTypeMap(resourceType, map, resolver);
+                modelClass = getClassFromResourceTypeMap(resourceType, map, resolver, adapterType);
                 if (modelClass != null) {
-                    return modelClass;
+                    return (Class<ModelType>) modelClass;
                 } else {
                     resourceType = resolver.getParentResourceType(resourceType);
                 }
             }
             Resource resourceTypeResource = resolver.getResource(originalResourceType);
-            return getModelClassForResource(resourceTypeResource, map);
+            return getModelClassForResource(resourceTypeResource, map, adapterType);
         }
     }
 
-    private static Class<?> getClassFromResourceTypeMap(final String resourceType, final Map<String, Class<?>> map, final ResourceResolver resolver) {
-        Class<?> modelClass = map.get(resourceType);
-        if (modelClass == null) {
+    private static <ModelType> Class<ModelType> getClassFromResourceTypeMap(final String resourceType,
+            final Map<String, ConcurrentNavigableMap<String, Class<?>>> map, final ResourceResolver resolver,
+            Class<ModelType> adapterType) {
+        Map<String, Class<?>> candidates = map.get(resourceType);
+        if (candidates == null || candidates.isEmpty()) {
             for (String searchPath : resolver.getSearchPath()) {
                 if (resourceType.startsWith("/")) {
                     if (resourceType.startsWith(searchPath)) {
-                        modelClass = map.get(resourceType.substring(searchPath.length()));
-                        if (modelClass != null) {
+                        candidates = map.get(resourceType.substring(searchPath.length()));
+                        if (candidates != null && !candidates.isEmpty()) {
                             break;
                         }
                     }
                 } else {
-                    modelClass = map.get(searchPath + resourceType);
-                    if (modelClass != null) {
+                    candidates = map.get(searchPath + resourceType);
+                    if (candidates != null && !candidates.isEmpty()) {
                         break;
                     }
                 }
             }
         }
-        return modelClass;
+
+        if (adapterType != null && candidates != null) {
+            return (Class<ModelType>) candidates.get(adapterType.getName());
+        } else {
+            return (Class<ModelType>) (candidates != null && !candidates.isEmpty() ?
+                    candidates.entrySet().iterator().next().getValue() :
+                    null);
+        }
     }
 
-    Map<String, Class<?>> getResourceTypeMappingsForRequests() {
+    Map<String, ConcurrentNavigableMap<String, Class<?>>> getResourceTypeMappingsForRequests() {
         return Collections.unmodifiableMap(resourceTypeMappingsForRequests);
     }
 
-    Map<String, Class<?>> getResourceTypeMappingsForResources() {
+    Map<String, ConcurrentNavigableMap<String, Class<?>>> getResourceTypeMappingsForResources() {
         return Collections.unmodifiableMap(resourceTypeMappingsForResources);
     }
 }

--- a/bundles/extensions/models/impl/src/main/java/org/apache/sling/models/impl/ModelConfigurationPrinter.java
+++ b/bundles/extensions/models/impl/src/main/java/org/apache/sling/models/impl/ModelConfigurationPrinter.java
@@ -18,7 +18,9 @@ package org.apache.sling.models.impl;
 
 import java.io.PrintWriter;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentNavigableMap;
 
 import org.apache.sling.models.spi.ImplementationPicker;
 import org.apache.sling.models.spi.Injector;
@@ -102,18 +104,22 @@ public class ModelConfigurationPrinter {
 
         // models bound to resource types
         printWriter.println("Sling Models Bound to Resource Types *For Resources*:");
-        for (Map.Entry<String, Class<?>> entry : adapterImplementations.getResourceTypeMappingsForResources().entrySet()) {
-            printWriter.print(entry.getValue().getName());
-            printWriter.print(" - ");
-            printWriter.println(entry.getKey());
+        for (Map.Entry<String, ConcurrentNavigableMap<String, Class<?>>> entry : adapterImplementations.getResourceTypeMappingsForResources().entrySet()) {
+            for(Class<?> clazz : entry.getValue().values()) {
+                printWriter.print(clazz.getName());
+                printWriter.print(" - ");
+                printWriter.println(entry.getKey());
+            }
         }
         printWriter.println();
 
         printWriter.println("Sling Models Bound to Resource Types *For Requests*:");
-        for (Map.Entry<String, Class<?>> entry : adapterImplementations.getResourceTypeMappingsForRequests().entrySet()) {
-            printWriter.print(entry.getValue().getName());
-            printWriter.print(" - ");
-            printWriter.println(entry.getKey());
+        for (Map.Entry<String, ConcurrentNavigableMap<String, Class<?>>> entry : adapterImplementations.getResourceTypeMappingsForRequests().entrySet()) {
+            for(Class<?> clazz : entry.getValue().values()) {
+                printWriter.print(clazz.getName());
+                printWriter.print(" - ");
+                printWriter.println(entry.getKey());
+            }
         }
 
         printWriter.println();

--- a/bundles/extensions/models/impl/src/test/java/org/apache/sling/models/impl/AdapterImplementationsTest.java
+++ b/bundles/extensions/models/impl/src/test/java/org/apache/sling/models/impl/AdapterImplementationsTest.java
@@ -157,9 +157,10 @@ public class AdapterImplementationsTest {
         // ensure that trying to reregister the resource type is a no-op
         BundleContext secondBundleContext = MockOsgi.newBundleContext();
         underTest.registerModelToResourceType(secondBundleContext.getBundle(), "sling/rt/one", Resource.class, Integer.class);
-        assertEquals(String.class, underTest.getModelClassForResource(resource));
-        assertEquals(String.class, underTest.getModelClassForResource(childResource));
+        assertEquals(Integer.class, underTest.getModelClassForResource(resource));
+        assertEquals(Integer.class, underTest.getModelClassForResource(childResource));
 
+        underTest.removeResourceTypeBindings(secondBundleContext.getBundle());
         underTest.removeResourceTypeBindings(bundleContext.getBundle());
         assertNull(underTest.getModelClassForResource(resource));
         assertNull(underTest.getModelClassForResource(childResource));
@@ -234,11 +235,13 @@ public class AdapterImplementationsTest {
         assertEquals(String.class, underTest.getModelClassForRequest(request));
         assertEquals(Integer.class, underTest.getModelClassForResource(resource));
 
-        // ensure that trying to reregister the resource type is a no-op
+        // ensure that trying to reregister the resource type which is smaller in natural order, will be ordered in front of the existing
+        // adapater implementation for the same resource type
         BundleContext secondBundleContext = MockOsgi.newBundleContext();
         underTest.registerModelToResourceType(secondBundleContext.getBundle(), "sling/rt/one", SlingHttpServletRequest.class, Integer.class);
-        assertEquals(String.class, underTest.getModelClassForRequest(request));
+        assertEquals(Integer.class, underTest.getModelClassForRequest(request));
 
+        underTest.removeResourceTypeBindings(secondBundleContext.getBundle());
         underTest.removeResourceTypeBindings(bundleContext.getBundle());
         assertNull(underTest.getModelClassForRequest(request));
         assertNull(underTest.getModelClassForResource(resource));


### PR DESCRIPTION
This pull requests enables 1 to many binding from resourceType to model.

IMHO the implementation is quite ugly because of the way resourceType binding is defined. In the current interface the untyped methods `getModelFromResource(Resource)` and `getModelFromRequest(SlingHttpServletRequest)` have been added to `ModelFactory`. Those are not conform to the way the `ModelFactory` implementation work: creating a typed object from something. I understood that the usecase for the jackson exporter doesn't require a typed object as exporting an ordinary one works quite well but it makes hard to decide which adapterType should be used in case multiple are registered for a single resourceType. Having said that I deprecated those methods along with related ones, but still supporting their expected functionality, with only a slightly difference as adapterTypes are now sorted alphabetically - the same way its done for the original adapter implementations. Anyway removing those, or throwing `USOE` would make sense, to make the API clean again. Most of the code added to `AdapterImplementations` can and should be moved to the related `ImplementationPicker` using it which is supposed to decide which implementation to use based on the adaptable's resourceType. For the exporter a slightly adjustment would be necessary, which is now also implemented: Keeping in mind that class level annotations are not inherited, there is a 1:1 relation between `@Exporter` and its implementation class and with that we can implicitly add the `implType` to the `adapterTypes` if not already present. As the `implType` is known to the `ExporterServlet` anyway it can use it to get the typed object for exporting.