### PR TITLE
SLING-6658:

### DIFF
--- a/bundles/extensions/models/impl/src/main/java/org/apache/sling/models/impl/ModelPackageBundleListener.java
+++ b/bundles/extensions/models/impl/src/main/java/org/apache/sling/models/impl/ModelPackageBundleListener.java
@@ -26,6 +26,7 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.adapter.AdapterFactory;
@@ -143,6 +144,8 @@ public class ModelPackageBundleListener implements BundleTrackerCustomizer {
                 Class<?>[] adapterTypes = annotation.adapters();
                 if (adapterTypes.length == 0) {
                     adapterTypes = new Class<?>[] { implType };
+                } else if (!ArrayUtils.contains(adapterTypes, implType)) {
+                    adapterTypes = (Class<?>[]) ArrayUtils.add(adapterTypes, implType);
                 }
                 // register adapter only if given adapters are valid
                 if (validateAdapterClasses(implType, adapterTypes)) {

--- a/bundles/extensions/models/integration-tests/src/main/java/org/apache/sling/models/it/ImplementsExtendsTest.java
+++ b/bundles/extensions/models/integration-tests/src/main/java/org/apache/sling/models/it/ImplementsExtendsTest.java
@@ -85,12 +85,12 @@ public class ImplementsExtendsTest {
     }
 
     /**
-     * Ensure that the implementation class itself cannot be adapted to if it is not part of the "adapter" property in the annotation.
+     * Ensure that the implementation class itself can be adapted to, even if it is not part of the "adapter" property in the annotation.
      */
     @Test
-    public void testImplementsInterfaceModel_ImplClassNotMapped() {
+    public void testImplementsInterfaceModel_ImplClassImplicitlyMapped() {
         ImplementsInterfacePropertyModel model = adapterManager.getAdapter(resource, ImplementsInterfacePropertyModel.class);
-        assertNull(model);
+        assertNotNull(model); 
     }
 
     /**


### PR DESCRIPTION
 - always reigster the model with its implType, even not specified as adapter explicitly