### PR TITLE
SLING-6783 updates for org.apache.commons.html

### DIFF
--- a/contrib/commons/html/NOTICE
+++ b/contrib/commons/html/NOTICE
@@ -8,4 +8,4 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 This product includes software developed at
-http://home.ccil.org/~cowan/XML/tagsoup/
+http://vrici.lojban.org/~cowan/XML/tagsoup/

--- a/contrib/commons/html/README.md
+++ b/contrib/commons/html/README.md
@@ -1,0 +1,39 @@
+# current settings and their default values
+
+* http://xml.org/sax/features/namespaces=true
+* http://xml.org/sax/features/namespace-prefixes=false
+* http://xml.org/sax/features/external-general-entities=false
+* http://xml.org/sax/features/external-parameter-entities=false
+* http://xml.org/sax/features/is-standalone=false
+* http://xml.org/sax/features/lexical-handler/parameter-entities=false
+* http://xml.org/sax/features/resolve-dtd-uris=true
+* http://xml.org/sax/features/string-interning=true
+* http://xml.org/sax/features/use-attributes2=false
+* http://xml.org/sax/features/use-locator2=false
+* http://xml.org/sax/features/use-entity-resolver2=false
+* http://xml.org/sax/features/validation=false
+* http://xml.org/sax/features/xmlns-uris=false
+* http://xml.org/sax/features/xmlns-uris=false
+* http://xml.org/sax/features/xml-1.1=false
+
+default SAX features are defined here
+http://www.saxproject.org/apidoc/org/xml/sax/package-summary.html
+
+tagsoup specific features are
+
+*  http://www.ccil.org/~cowan/tagsoup/features/ignore-bogons=false
+   A value of "true" indicates that the parser will ignore unknown elements.
+*  http://www.ccil.org/~cowan/tagsoup/features/bogons-empty=false
+   A value of "true" indicates that the parser will give unknown elements a content model of EMPTY; a value of "false", a content model of ANY.
+*  http://www.ccil.org/~cowan/tagsoup/features/root-bogons=true
+   A value of "true" indicates that the parser will allow unknown elements to be the root of the output document.
+*  http://www.ccil.org/~cowan/tagsoup/features/default-attributes=true
+   A value of "true" indicates that the parser will return default attribute values for missing attributes that have default values.
+* http://www.ccil.org/~cowan/tagsoup/features/translate-colons=false
+  A value of "true" indicates that the parser will translate colons into underscores in names.
+* http://www.ccil.org/~cowan/tagsoup/features/restart-elements=true
+  A value of "true" indicates that the parser will attempt to restart the restartable elements.
+* http://www.ccil.org/~cowan/tagsoup/features/ignorable-whitespace=false
+  A value of "true" indicates that the parser will transmit whitespace in element-only content via the SAX ignorableWhitespace callback. Normally this is not done, because HTML is an SGML application and SGML suppresses such whitespace.
+* http://www.ccil.org/~cowan/tagsoup/features/cdata-elements=true
+  A value of "true" indicates that the parser will process the script and style elements (or any elements with type='cdata' in the TSSL schema) as SGML CDATA elements (that is, no markup is recognized except the matching end-tag).

--- a/contrib/commons/html/pom.xml
+++ b/contrib/commons/html/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling</artifactId>
-        <version>26</version>
+        <version>30</version>
         <relativePath/>
     </parent>
 
@@ -44,10 +44,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
@@ -85,11 +81,13 @@
         <dependency>
             <groupId>org.ccil.cowan.tagsoup</groupId>
             <artifactId>tagsoup</artifactId>
-            <version>1.2</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
+        	<groupId>org.apache.sling</groupId>
+        	<artifactId>org.apache.sling.commons.osgi</artifactId>
+        	<version>2.2.0</version>
+        	<scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/contrib/commons/html/src/main/java/org/apache/sling/commons/html/impl/HtmlParserImpl.java
+++ b/contrib/commons/html/src/main/java/org/apache/sling/commons/html/impl/HtmlParserImpl.java
@@ -20,11 +20,16 @@ package org.apache.sling.commons.html.impl;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Map;
 
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.Service;
 import org.apache.sling.commons.html.HtmlParser;
+import org.apache.sling.commons.osgi.PropertiesUtil;
 import org.ccil.cowan.tagsoup.Parser;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 import org.w3c.dom.Document;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.InputSource;
@@ -32,8 +37,19 @@ import org.xml.sax.SAXException;
 import org.xml.sax.ext.LexicalHandler;
 
 @Component
-@Service(value=HtmlParser.class)
+@Designate(ocd = HtmlParserImpl.Config.class)
 public class HtmlParserImpl implements HtmlParser {
+	
+    @ObjectClassDefinition(name="Apache Sling HTML Parser", description="Parser configuration")
+    static @interface Config {
+ 
+        @AttributeDefinition(name = "Parser Properties",
+                description = "Additional properties to be applied to the underlying parser in the format of key=[true|false]")
+        String[] properties();
+    
+    }
+    
+    private Map<String,Boolean> features;
 
     /**
      * @see org.apache.sling.commons.html.HtmlParser#parse(java.io.InputStream, java.lang.String, org.xml.sax.ContentHandler)
@@ -43,6 +59,11 @@ public class HtmlParserImpl implements HtmlParser {
         final Parser parser = new Parser();
         if ( ch instanceof LexicalHandler ) {
             parser.setProperty("http://xml.org/sax/properties/lexical-handler", ch);
+        }
+        if (!features.isEmpty()){
+        	for (String feature:features.keySet()){
+        		parser.setProperty(feature, features.get(feature));
+        	}
         }
         parser.setContentHandler(ch);
         final InputSource source = new InputSource(stream);
@@ -68,6 +89,11 @@ public class HtmlParserImpl implements HtmlParser {
 
         try {
             parser.setProperty("http://xml.org/sax/properties/lexical-handler", builder);
+            if (!features.isEmpty()){
+				for (String feature : features.keySet()) {
+					parser.setProperty(feature, features.get(feature));
+				}
+            }
             parser.setContentHandler(builder);
             parser.parse(source);
         } catch (SAXException se) {
@@ -77,5 +103,13 @@ public class HtmlParserImpl implements HtmlParser {
             throw (IOException) new IOException("Unable to parse xml.").initCause(se);
         }
         return builder.getDocument();
+    }
+    
+    @Activate
+    private void activate(Config config) {
+    	Map<String,String> temp = PropertiesUtil.toMap(config.properties(), new String[]{});
+    	for (String key : temp.keySet()){
+    		features.put(key, Boolean.valueOf(temp.get(key)));
+    	}
     }
 }


### PR DESCRIPTION
- tagsoup jar update
- updated annotations
- added readme for available configuration options
- updated tagsoup homepage
- added ability to add configurations parameters/features to parser instance

this is groundwork for html5 support