### PR TITLE
sling-3270 minimal extension of the anchor tag

### DIFF
--- a/contrib/commons/html/src/main/java/org/apache/sling/commons/html/impl/HTMLExtendedSchema.java
+++ b/contrib/commons/html/src/main/java/org/apache/sling/commons/html/impl/HTMLExtendedSchema.java
@@ -1,0 +1,18 @@
+package org.apache.sling.commons.html.impl;
+
+import org.ccil.cowan.tagsoup.ElementType;
+import org.ccil.cowan.tagsoup.HTMLSchema;
+
+/**
+ * Implements support for the anchor tag to contain content. This implementation
+ * does not fully support HTML5 as such, it does address the most common issue.
+ */
+public class HTMLExtendedSchema extends HTMLSchema {
+
+	public HTMLExtendedSchema() {
+		super();
+		ElementType anchor = getElementType("a");
+		anchor.setMemberOf(M_INLINE | M_BLOCKINLINE | M_BLOCK);
+	}
+
+}

--- a/contrib/commons/html/src/main/java/org/apache/sling/commons/html/impl/HtmlParserImpl.java
+++ b/contrib/commons/html/src/main/java/org/apache/sling/commons/html/impl/HtmlParserImpl.java
@@ -57,6 +57,7 @@ public class HtmlParserImpl implements HtmlParser {
     public void parse(InputStream stream, String encoding, ContentHandler ch)
     throws SAXException {
         final Parser parser = new Parser();
+        parser.setProperty("http://www.ccil.org/~cowan/tagsoup/properties/schema", new HTMLExtendedSchema());
         if ( ch instanceof LexicalHandler ) {
             parser.setProperty("http://xml.org/sax/properties/lexical-handler", ch);
         }
@@ -87,6 +88,7 @@ public class HtmlParserImpl implements HtmlParser {
 
         try {
             parser.setProperty("http://xml.org/sax/properties/lexical-handler", builder);
+            parser.setProperty("http://www.ccil.org/~cowan/tagsoup/properties/schema", new HTMLExtendedSchema());
             for (String feature : features.keySet()) {
                 parser.setProperty(feature, features.get(feature));
             }


### PR DESCRIPTION
allows the anchor tag to wrap additional content. this will address the most common issue being reported with using tagsoup and html5