### PR TITLE
Fix a cross-site scripting vulnerability in the SlingLogPanel.

### DIFF
--- a/bundles/commons/log/src/main/java/org/apache/sling/commons/log/logback/internal/SlingLogPanel.java
+++ b/bundles/commons/log/src/main/java/org/apache/sling/commons/log/logback/internal/SlingLogPanel.java
@@ -572,7 +572,7 @@ public class SlingLogPanel implements LogPanel {
                 return;
             }
         }
-        pw.printf("No appender with name [%s] found", appenderName);
+        pw.printf("No appender with name [%s] found", XmlUtil.escapeXml(appenderName));
     }
 
     private String getLinkedName(FileAppender<ILoggingEvent> appender) throws UnsupportedEncodingException {


### PR DESCRIPTION
The log appender name is a user provided value originating [here](/apache/sling/blob/f0e4561935cbebfe6f84a85622513baa74e72d44/bundles/commons/log-webconsole/src/main/java/org/apache/sling/commons/log/webconsole/internal/LogWebConsolePlugin.java#L65), therefore it should not be written to the output HTML without being sanitized.