### PR TITLE
Adds missing assignment of name in MockRequestParameter.

### DIFF
--- a/bundles/extensions/servlet-helpers/src/main/java/org/apache/sling/servlethelpers/MockRequestParameter.java
+++ b/bundles/extensions/servlet-helpers/src/main/java/org/apache/sling/servlethelpers/MockRequestParameter.java
@@ -36,6 +36,7 @@ class MockRequestParameter implements RequestParameter {
     private byte[] content;
 
     public MockRequestParameter(String name, String value) {
+        this.name = name;
         this.value = value;
         this.content = null;
     }


### PR DESCRIPTION
I stumbled across this missing assignment when I wrote unit tests for Adobe AEM in combination with AEM mocks (wcm.io.testing).