### PR TITLE
SLING-6855 Add ResultRegistry

### DIFF
--- a/bundles/extensions/healthcheck/api/pom.xml
+++ b/bundles/extensions/healthcheck/api/pom.xml
@@ -67,6 +67,12 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>2.0.0</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/bundles/extensions/healthcheck/api/src/main/java/org/apache/sling/hc/api/ResultRegistry.java
+++ b/bundles/extensions/healthcheck/api/src/main/java/org/apache/sling/hc/api/ResultRegistry.java
@@ -22,7 +22,7 @@ import java.util.Calendar;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.osgi.annotation.versioning.ConsumerType;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
  * ResultRegistry is a service that can be leveraged to provide health check results.
@@ -44,7 +44,7 @@ import org.osgi.annotation.versioning.ConsumerType;
  * setting the expiration to that window can be ideal.
  *
  */
-@ConsumerType
+@ProviderType
 public interface ResultRegistry extends HealthCheck {
     /**
      * Put result which will be reported in the health check list until the expiration
@@ -60,8 +60,9 @@ public interface ResultRegistry extends HealthCheck {
      * @param result The object to report until expiration.
      * @param expiration When the system time is after this time, the result is removed from the
      *  list of health checks. If the expiration is null, the result never expires.
+     * @param tags a list of tags to apply to this result
      */
-    void put(@Nonnull String identifier, @Nonnull Result result, @Nullable Calendar expiration);
+    void put(@Nonnull String identifier, @Nonnull Result result, @Nullable Calendar expiration, @Nullable String... tags);
     
     /**
      * removes the health check information

--- a/bundles/extensions/healthcheck/api/src/main/java/org/apache/sling/hc/api/ResultRegistry.java
+++ b/bundles/extensions/healthcheck/api/src/main/java/org/apache/sling/hc/api/ResultRegistry.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The SF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.sling.hc.api;
+
+import java.util.Calendar;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.osgi.annotation.versioning.ConsumerType;
+
+/**
+ * ResultRegistry is a service that can be leveraged to provide health check results.
+ * These results can be for a period of time through an expiration, until the JVM is 
+ * restarted, or added and later removed.
+ * 
+ * This can be useful when code observes a specific (possibly bad) state, and wants to 
+ * alert through the health check API that this state has taken place.
+ * 
+ * Some examples: 
+ *  An event pool has filled, and some events will be thrown away.
+ *   This is a failure case that requires a restart of the instance.
+ *   It would be appropriate to trigger a permanent failure.
+ *  
+ *  A quota has been tripped. This quota may immediately recover, but it is sensible to 
+ *   alert for 30 minutes that the quota has been tripped.
+ * 
+ * If you expect the failure will clear itself within a certain window, 
+ * setting the expiration to that window can be ideal.
+ *
+ */
+@ConsumerType
+public interface ResultRegistry extends HealthCheck {
+    /**
+     * Put result which will be reported in the health check list until the expiration
+     *  has passed, the system is restarted, or the result has been removed by identifier.
+     * @param identifier A unique identifier for this health check result. 
+     *  This should be "package.class:method" to avoid collisions and be identifiable. 
+     *  
+     *  Putting a result with the same ID will replace the stored result and expiration 
+     *   if the stored entry is of a lower or equal status level.
+     *  
+     *  If a stored entry is of a higher status level, and the status of the result being put
+     *   is of warn or above, the later of the two expirations will be used for the stored entry
+     * @param result The object to report until expiration.
+     * @param expiration When the system time is after this time, the result is removed from the
+     *  list of health checks. If the expiration is null, the result never expires.
+     */
+    void put(@Nonnull String identifier, @Nonnull Result result, @Nullable Calendar expiration);
+    
+    /**
+     * removes the health check information
+     * @param identifier
+     */
+    void remove(@Nonnull String identifier);
+}

--- a/bundles/extensions/healthcheck/api/src/main/java/org/apache/sling/hc/api/package-info.java
+++ b/bundles/extensions/healthcheck/api/src/main/java/org/apache/sling/hc/api/package-info.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-@Version("1.1.0")
+@Version("1.2.0")
 package org.apache.sling.hc.api;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/extensions/healthcheck/core/pom.xml
+++ b/bundles/extensions/healthcheck/core/pom.xml
@@ -260,6 +260,13 @@
       </dependency>
 
       <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+        <version>2.0.0</version>
+        <scope>provided</scope>
+      </dependency>
+        
+      <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>2.5</version>

--- a/bundles/extensions/healthcheck/core/pom.xml
+++ b/bundles/extensions/healthcheck/core/pom.xml
@@ -273,4 +273,14 @@
         <scope>test</scope>
       </dependency>
      </dependencies>
+     
+     <dependencyManagement>
+       <dependencies>
+         <dependency>
+          <groupId>org.osgi</groupId>
+          <artifactId>org.osgi.core</artifactId>
+          <version>4.3.0</version>
+         </dependency>
+       </dependencies>
+     </dependencyManagement>
 </project>

--- a/bundles/extensions/healthcheck/core/src/main/java/org/apache/sling/hc/core/impl/ResultRegistryImpl.java
+++ b/bundles/extensions/healthcheck/core/src/main/java/org/apache/sling/hc/core/impl/ResultRegistryImpl.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The SF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.sling.hc.core.impl;
+
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.sling.hc.api.HealthCheck;
+import org.apache.sling.hc.api.Result;
+import org.apache.sling.hc.api.ResultLog;
+import org.apache.sling.hc.api.ResultLog.Entry;
+import org.apache.sling.hc.api.ResultRegistry;
+import org.apache.sling.hc.api.Result.Status;
+
+@Component()
+@Service(value={ResultRegistry.class, HealthCheck.class})
+public class ResultRegistryImpl implements ResultRegistry {
+    
+    private Map<String, TimedResult> activeResults = new HashMap<String, TimedResult>(500, 0.75f);
+    
+    @Override
+    public void put(@Nonnull String identifier, @Nonnull Result result, @Nullable Calendar expiration) {
+        if(expiration != null && expiration.before(Calendar.getInstance())) {
+            return;
+        }
+        synchronized(activeResults) {
+            TimedResult previous = activeResults.get(identifier);
+            if(previous != null && previous.expiration != null && previous.expiration.before(Calendar.getInstance())) {
+                previous = null;
+            }
+            if(previous != null && previous.result.getStatus().ordinal() > result.getStatus().ordinal()) {
+                //the previous entry is more important. 
+                //Do we need to update the calendar of the previous entry?
+                if(previous.expiration != null && result.getStatus().ordinal() >= Result.Status.WARN.ordinal()) {
+                    //potentially.
+                    if(expiration == null) {
+                        previous.expiration = null;
+                    }
+                    else if(previous.expiration.before(expiration)) {
+                        previous.expiration = expiration;
+                    }
+                    //else nothing to change for previous entry
+                }
+                return; //do not store this new entry, because previous is more important.
+            }
+            activeResults.put(identifier, new TimedResult(result, expiration));
+        }
+    }
+
+    @Override
+    public void remove(@Nonnull String identifier) {
+        synchronized (activeResults) {
+            activeResults.remove(identifier);
+        }
+    }
+    
+    @Override
+    public Result execute() {
+        Collection<IdentifiedResult> results = getActiveResults();
+        if(results.isEmpty()) {
+            return new Result(Status.OK, "No results to report");
+        }
+        
+        ResultLog resultLog = new ResultLog();
+        for (IdentifiedResult identifiedResult : results) {
+            for (Entry entry : identifiedResult.result) {
+                resultLog.add(new ResultLog.Entry(entry.getStatus(), identifiedResult.identifier + ": " + entry.getMessage(), entry.getException()));
+            }
+        }
+
+        return new Result(resultLog);
+    }
+    
+    private void removeExpiredResultIfSame(@Nonnull String identifier, @Nonnull TimedResult result) {
+        synchronized(activeResults) {
+            if(activeResults.get(identifier) == result) {
+                activeResults.remove(identifier);
+            }
+        }
+    }
+    
+    private Collection<IdentifiedResult> getActiveResults() {
+        //TreeMap will keep the ordering consistent.
+        final TreeMap<String, IdentifiedResult> results = new TreeMap<String, IdentifiedResult>();
+        final Calendar now = Calendar.getInstance();
+        for(String identifier : activeResults.keySet().toArray(new String[0])) {
+            TimedResult tr = activeResults.get(identifier);
+            if(tr == null) {
+                continue;
+            }
+            if(tr.expiration != null && tr.expiration.before(now)) {
+                removeExpiredResultIfSame(identifier, tr);
+                continue;
+            }
+            results.put(identifier, new IdentifiedResult(identifier, tr.result));
+        }
+        return results.values();
+    }
+    
+    private class TimedResult {
+        @Nonnull
+        final Result result;
+        @Nullable
+        Calendar expiration;
+        public TimedResult(@Nonnull Result result, @Nullable Calendar expiration) {
+            this.result = result;
+            this.expiration = expiration;
+        }
+    }
+    
+    private class IdentifiedResult {
+        @Nonnull
+        final String identifier;
+        @Nonnull
+        final Result result;
+        public IdentifiedResult(String identifier, Result result) {
+            super();
+            this.identifier = identifier;
+            this.result = result;
+        }
+    }
+}

--- a/bundles/extensions/healthcheck/core/src/main/java/org/apache/sling/hc/core/impl/ResultRegistryImpl.java
+++ b/bundles/extensions/healthcheck/core/src/main/java/org/apache/sling/hc/core/impl/ResultRegistryImpl.java
@@ -19,34 +19,57 @@ package org.apache.sling.hc.core.impl;
 
 import java.util.Calendar;
 import java.util.Collection;
+import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
+import java.util.TreeSet;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import org.apache.felix.scr.annotations.Activate;
 import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Deactivate;
 import org.apache.felix.scr.annotations.Service;
 import org.apache.sling.hc.api.HealthCheck;
 import org.apache.sling.hc.api.Result;
+import org.apache.sling.hc.api.Result.Status;
 import org.apache.sling.hc.api.ResultLog;
 import org.apache.sling.hc.api.ResultLog.Entry;
 import org.apache.sling.hc.api.ResultRegistry;
-import org.apache.sling.hc.api.Result.Status;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-@Component()
-@Service(value={ResultRegistry.class, HealthCheck.class})
+@Component(immediate=true)
+@Service(value={ResultRegistry.class}) //HealthCheck.class is registered dynamically.
 public class ResultRegistryImpl implements ResultRegistry {
+
+    private static final String NAME = "Aggregating ResultRegistry Service";
     
+    private static final Logger log = LoggerFactory.getLogger(ResultRegistryImpl.class);
+    
+    @SuppressWarnings("rawtypes")
+    private ServiceRegistration healthCheckRegistration;
+
     private Map<String, TimedResult> activeResults = new HashMap<String, TimedResult>(500, 0.75f);
+    private Map<String, Set<String>> tags = new TreeMap<String, Set<String>>();
+    
+    private final Object semaphore = new Object();
     
     @Override
-    public void put(@Nonnull String identifier, @Nonnull Result result, @Nullable Calendar expiration) {
+    public void put(@Nonnull String identifier, @Nonnull Result result, @Nullable Calendar expiration, @Nullable String... tags) {
         if(expiration != null && expiration.before(Calendar.getInstance())) {
             return;
         }
-        synchronized(activeResults) {
+        if(tags == null) {
+            tags = new String[0];
+        }
+        
+        synchronized(semaphore) {
             TimedResult previous = activeResults.get(identifier);
             if(previous != null && previous.expiration != null && previous.expiration.before(Calendar.getInstance())) {
                 previous = null;
@@ -66,14 +89,78 @@ public class ResultRegistryImpl implements ResultRegistry {
                 }
                 return; //do not store this new entry, because previous is more important.
             }
-            activeResults.put(identifier, new TimedResult(result, expiration));
+            final TimedResult old = activeResults.get(identifier);
+            if(old != null) {
+                removeNoBuild(identifier, old); //remove fixes tags
+            }
+            activeResults.put(identifier, new TimedResult(result, expiration, tags));
+            for(String tag : tags) {
+                if(!this.tags.containsKey(tag)) {
+                    this.tags.put(tag, new TreeSet<String>());
+                }
+                Set<String> names = this.tags.get(tag);
+                names.add(identifier);
+            }
+            
+            buildProperties();
         }
+    }
+    
+
+    
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private void buildProperties() {
+        if(healthCheckRegistration == null) {
+            log.warn("Unable to build properties, lacking service registration");
+            return;
+        }
+        Dictionary d = new java.util.Properties();
+        d.put(HealthCheck.NAME, NAME);
+        d.put(HealthCheck.MBEAN_NAME, NAME);
+        d.put(HealthCheck.TAGS, tags.keySet().toArray(new String[0]));
+        healthCheckRegistration.setProperties(d);
+    }
+    
+    
+    @Activate
+    public void activate(BundleContext context) {
+        healthCheckRegistration = context.registerService(HealthCheck.class, (HealthCheck)this, null);
+        buildProperties();
+    }
+    
+    @Deactivate
+    public void deactivate(BundleContext context) {
+        if(healthCheckRegistration != null) {
+            healthCheckRegistration.unregister();
+        }
+        healthCheckRegistration = null;
     }
 
     @Override
     public void remove(@Nonnull String identifier) {
-        synchronized (activeResults) {
-            activeResults.remove(identifier);
+        TimedResult ir = activeResults.get(identifier);
+        if(ir != null) {
+            removeNoBuild(identifier, ir);
+            buildProperties();
+        }
+    }
+
+    private void removeNoBuild(@Nonnull String identifier, @Nonnull TimedResult result) {
+        synchronized (semaphore) {
+            if(activeResults.remove(identifier) != null) {
+                for(String tag : result.tags) {
+                    Set<String> tagList = tags.get(tag);
+                    if(tagList == null) {
+                        continue; //shouldn't happen.
+                    }
+                    if(tagList.contains(identifier)) {
+                        tagList.remove(identifier); //should always happen
+                    }
+                    if(tagList.isEmpty()) {
+                        tags.remove(tag);
+                    }
+                }
+            }
         }
     }
     
@@ -81,7 +168,10 @@ public class ResultRegistryImpl implements ResultRegistry {
     public Result execute() {
         Collection<IdentifiedResult> results = getActiveResults();
         if(results.isEmpty()) {
-            return new Result(Status.OK, "No results to report");
+            ResultLog rv = new ResultLog();
+            
+            rv.add(new Entry(Status.OK, "Nothing to report"));
+            return new Result(rv);
         }
         
         ResultLog resultLog = new ResultLog();
@@ -94,28 +184,40 @@ public class ResultRegistryImpl implements ResultRegistry {
         return new Result(resultLog);
     }
     
-    private void removeExpiredResultIfSame(@Nonnull String identifier, @Nonnull TimedResult result) {
-        synchronized(activeResults) {
+
+    /**
+     * returns true if actually removed.
+     */
+    private boolean removeExpiredResultIfSame(@Nonnull String identifier, @Nonnull TimedResult result) {
+        synchronized(semaphore) {
             if(activeResults.get(identifier) == result) {
-                activeResults.remove(identifier);
+                remove(identifier);
+                return true;
             }
         }
+        return false;
     }
     
     private Collection<IdentifiedResult> getActiveResults() {
         //TreeMap will keep the ordering consistent.
         final TreeMap<String, IdentifiedResult> results = new TreeMap<String, IdentifiedResult>();
         final Calendar now = Calendar.getInstance();
+        boolean recalculateTags = false;
         for(String identifier : activeResults.keySet().toArray(new String[0])) {
             TimedResult tr = activeResults.get(identifier);
             if(tr == null) {
                 continue;
             }
             if(tr.expiration != null && tr.expiration.before(now)) {
-                removeExpiredResultIfSame(identifier, tr);
+                if(removeExpiredResultIfSame(identifier, tr)) {
+                    recalculateTags = true;
+                }
                 continue;
             }
-            results.put(identifier, new IdentifiedResult(identifier, tr.result));
+            results.put(identifier, new IdentifiedResult(identifier, tr.result, tr.tags));
+        }
+        if(recalculateTags) {
+            buildProperties();
         }
         return results.values();
     }
@@ -125,9 +227,12 @@ public class ResultRegistryImpl implements ResultRegistry {
         final Result result;
         @Nullable
         Calendar expiration;
-        public TimedResult(@Nonnull Result result, @Nullable Calendar expiration) {
+        @Nonnull 
+        final String[] tags;
+        public TimedResult(@Nonnull Result result, @Nullable Calendar expiration, @Nonnull String[] tags) {
             this.result = result;
             this.expiration = expiration;
+            this.tags = tags;
         }
     }
     
@@ -136,10 +241,13 @@ public class ResultRegistryImpl implements ResultRegistry {
         final String identifier;
         @Nonnull
         final Result result;
-        public IdentifiedResult(String identifier, Result result) {
+        @Nonnull 
+        final String[] tags;
+        public IdentifiedResult(@Nonnull String identifier, @Nonnull Result result, @Nonnull String[] tags) {
             super();
             this.identifier = identifier;
             this.result = result;
+            this.tags = tags;
         }
     }
 }

--- a/bundles/extensions/healthcheck/core/src/test/java/org/apache/sling/hc/core/impl/ResultRegistryTest.java
+++ b/bundles/extensions/healthcheck/core/src/test/java/org/apache/sling/hc/core/impl/ResultRegistryTest.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The SF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.sling.hc.core.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Calendar;
+
+import org.apache.sling.hc.api.Result;
+import org.junit.Test;
+
+public class ResultRegistryTest {
+
+    
+    @Test
+    public void testSingleSubmissionNoExpire() {
+        ResultRegistryImpl impl = new ResultRegistryImpl();
+        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), null);
+        Result rv = impl.execute();
+        assertEquals(Result.Status.CRITICAL, rv.getStatus());
+        assertContains("identifier", rv.toString());
+        assertContains("mycritical", rv.toString());
+    }
+
+    @Test
+    public void testSingleSubmissionExpireInFuture() {
+        ResultRegistryImpl impl = new ResultRegistryImpl();
+        Calendar c = Calendar.getInstance();
+        c.add(Calendar.HOUR, 1);
+        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c);
+        Result rv = impl.execute();
+        assertEquals(Result.Status.CRITICAL, rv.getStatus());
+        assertContains("identifier", rv.toString());
+        assertContains("mycritical", rv.toString());
+    }
+
+    @Test
+    public void testSingleSubmissionExpireInPast() {
+        ResultRegistryImpl impl = new ResultRegistryImpl();
+        Calendar c = Calendar.getInstance();
+        c.add(Calendar.HOUR, 1); //future lets it be stored
+        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c);
+        c.add(Calendar.HOUR, -2); //make the calendar reference become expired.
+        Result rv = impl.execute();
+        assertEquals(Result.Status.OK, rv.getStatus());
+    }
+
+    @Test
+    public void testSingleSubmissionChangeWithExpired() {
+        ResultRegistryImpl impl = new ResultRegistryImpl();
+        Calendar c = Calendar.getInstance();
+        c.add(Calendar.HOUR, 1); //future lets it be stored
+        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c);
+        c = Calendar.getInstance();
+        c.add(Calendar.HOUR, -1);
+        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c); 
+        
+        Result rv = impl.execute();
+        assertEquals(Result.Status.CRITICAL, rv.getStatus());
+    }
+    
+    
+    @Test
+    public void testSingleSubmissionChangeFromDateToNull() {
+        ResultRegistryImpl impl = new ResultRegistryImpl();
+        Calendar c = Calendar.getInstance();
+        c.add(Calendar.HOUR, 1); //future lets it be stored
+        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c);
+        impl.put("identifier", new Result(Result.Status.WARN, "mycritical"), null); 
+        c.add(Calendar.HOUR, -100);
+        
+        Result rv = impl.execute();
+        assertEquals(Result.Status.CRITICAL, rv.getStatus());
+    }
+    
+    @Test
+    public void testSingleSubmissionChangeFromNullToDate() {
+        ResultRegistryImpl impl = new ResultRegistryImpl();
+        Calendar c = Calendar.getInstance();
+        c.add(Calendar.HOUR, 1); //future lets it be stored
+        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), null);
+        impl.put("identifier", new Result(Result.Status.WARN, "mywarn"), c); 
+        c.add(Calendar.HOUR, -100);
+        
+        Result rv = impl.execute();
+        assertEquals(Result.Status.CRITICAL, rv.getStatus());
+    }
+    
+    
+    @Test
+    public void testSingleSubmissionReplaceLessCritial() {
+        ResultRegistryImpl impl = new ResultRegistryImpl();
+        Calendar c = Calendar.getInstance();
+        c.add(Calendar.HOUR, 1); //future lets it be stored
+        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c);
+        c = Calendar.getInstance();
+        c.add(Calendar.HOUR, 1); //future lets it be stored
+        impl.put("identifier", new Result(Result.Status.OK, "myok"), c); //this new one should NOT remove the current one.
+        
+        Result rv = impl.execute();
+        assertEquals(Result.Status.CRITICAL, rv.getStatus());
+        assertContains("mycritical", rv.toString());
+        assertContains("identifier", rv.toString());
+    }
+    
+    @Test
+    public void testSingleSubmissionReplaceExpiredCriticalWithLessCritical() {
+        ResultRegistryImpl impl = new ResultRegistryImpl();
+        Calendar c = Calendar.getInstance();
+        c.add(Calendar.HOUR, 1); //future lets it be stored
+        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c);
+        c.set(Calendar.HOUR, -100); //exipred critical
+        c = Calendar.getInstance();
+        c.add(Calendar.HOUR, 1); //future lets it be stored
+        impl.put("identifier", new Result(Result.Status.WARN, "mywarn"), c); //this new one should remove the current one.
+        
+        Result rv = impl.execute();
+        assertEquals(Result.Status.WARN, rv.getStatus());
+        assertContains("mywarn", rv.toString());
+        assertContains("identifier", rv.toString());
+    }
+
+
+    @Test
+    public void testSingleSubmissionReplace() {
+        ResultRegistryImpl impl = new ResultRegistryImpl();
+        Calendar c = Calendar.getInstance();
+        c.add(Calendar.HOUR, 1); //future lets it be stored
+        impl.put("identifier", new Result(Result.Status.WARN, "mywarn"), c);
+        c = Calendar.getInstance();
+        c.add(Calendar.HOUR, 1); //future lets it be stored
+        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c); //this new one should remove the current one.
+        
+        Result rv = impl.execute();
+        assertEquals(Result.Status.CRITICAL, rv.getStatus());
+        assertNotContains("mywarn", rv.toString());
+        assertContains("identifier", rv.toString());
+        assertContains("mycritical", rv.toString());
+    }
+
+    @Test
+    public void testSingleSubmissionReplaceCalendar() {
+        ResultRegistryImpl impl = new ResultRegistryImpl();
+        Calendar c1 = Calendar.getInstance();
+        c1.add(Calendar.HOUR, 1); //future lets it be stored
+        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c1);
+        Calendar c2 = Calendar.getInstance();
+        c2.add(Calendar.HOUR, 2); //future lets it be stored
+        impl.put("identifier", new Result(Result.Status.WARN, "mywarn"), c2); //this new one should not replace the current one, but replace it's calendar.
+        
+        c1.add(Calendar.HOUR, -10); //making the first calendar expired.
+        
+        Result rv = impl.execute();
+        assertEquals(Result.Status.CRITICAL, rv.getStatus());
+        assertNotContains("mywarn", rv.toString());
+        assertContains("identifier", rv.toString());
+        assertContains("mycritical", rv.toString());
+    }
+    
+    
+    @Test
+    public void testSingleSubmissionAdd() {
+        ResultRegistryImpl impl = new ResultRegistryImpl();
+        Calendar c1 = Calendar.getInstance();
+        c1.add(Calendar.HOUR, 1); //future lets it be stored
+        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c1);
+        Calendar c2 = Calendar.getInstance();
+        c2.add(Calendar.HOUR, 1); //future lets it be stored
+        impl.put("newidentifier", new Result(Result.Status.OK, "myok"), c2); //this new one should add
+        
+        Result rv = impl.execute();
+        assertContains("identifier", rv.toString());
+        assertContains("newidentifier", rv.toString());
+        assertContains("mycritical", rv.toString());
+        assertContains("myok", rv.toString());
+        assertEquals(Result.Status.CRITICAL, rv.getStatus());
+    }
+
+    @Test
+    public void testSingleSubmissionRemove() {
+        ResultRegistryImpl impl = new ResultRegistryImpl();
+        Calendar c = Calendar.getInstance();
+        c.add(Calendar.HOUR, 1); //future lets it be stored
+        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c);
+        impl.remove("identifier");
+        
+        Result rv = impl.execute();
+        assertEquals(Result.Status.OK, rv.getStatus());
+    }
+    
+    void assertContains(String expected, String value) {
+        assertNotNull(expected);
+        assertNotNull(value);
+        assertTrue(value + " does not contain " + expected, value.contains(expected));
+    }
+    void assertNotContains(String expected, String value) {
+        assertNotNull(expected);
+        assertNotNull(value);
+        assertTrue(value + " contains " + expected, !value.contains(expected));
+    }
+}

--- a/bundles/extensions/healthcheck/core/src/test/java/org/apache/sling/hc/core/impl/ResultRegistryTest.java
+++ b/bundles/extensions/healthcheck/core/src/test/java/org/apache/sling/hc/core/impl/ResultRegistryTest.java
@@ -30,6 +30,7 @@ import java.util.Dictionary;
 import org.apache.sling.hc.api.HealthCheck;
 import org.apache.sling.hc.api.Result;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
@@ -59,8 +60,8 @@ public class ResultRegistryTest {
     @Test
     public void testSingleSubmissionExpireInFuture() {
         ResultRegistryImpl impl = new ResultRegistryImpl();
-        PhonyBundleContext pbc = new PhonyBundleContext();
-        impl.activate(pbc);
+        PhonyServiceRegistration pbc = new PhonyServiceRegistration();
+        impl.activate(getPhonyBundleContext(pbc));
         Calendar c = Calendar.getInstance();
         c.add(Calendar.HOUR, 1);
         impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical", null), c, "tag1");
@@ -74,8 +75,9 @@ public class ResultRegistryTest {
     @Test
     public void testSingleSubmissionExpireInPast() {
         ResultRegistryImpl impl = new ResultRegistryImpl();
-        PhonyBundleContext pbc = new PhonyBundleContext();
-        impl.activate(pbc);
+        PhonyServiceRegistration pbc = new PhonyServiceRegistration();
+        impl.activate(getPhonyBundleContext(pbc));
+
         Calendar c = Calendar.getInstance();
         c.add(Calendar.HOUR, 1); //future lets it be stored
         impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c, "tag1");
@@ -88,8 +90,8 @@ public class ResultRegistryTest {
     @Test
     public void testSingleSubmissionChangeWithExpired() {
         ResultRegistryImpl impl = new ResultRegistryImpl();
-        PhonyBundleContext pbc = new PhonyBundleContext();
-        impl.activate(pbc);
+        PhonyServiceRegistration pbc = new PhonyServiceRegistration();
+        impl.activate(getPhonyBundleContext(pbc));
         Calendar c = Calendar.getInstance();
         c.add(Calendar.HOUR, 1); //future lets it be stored
         impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c, "tag1");
@@ -107,8 +109,8 @@ public class ResultRegistryTest {
     @Test
     public void testSingleSubmissionChangeFromDateToNull() {
         ResultRegistryImpl impl = new ResultRegistryImpl();
-        PhonyBundleContext pbc = new PhonyBundleContext();
-        impl.activate(pbc);
+        PhonyServiceRegistration pbc = new PhonyServiceRegistration();
+        impl.activate(getPhonyBundleContext(pbc));
         Calendar c = Calendar.getInstance();
         c.add(Calendar.HOUR, 1); //future lets it be stored
         impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c, "tag1");
@@ -124,8 +126,8 @@ public class ResultRegistryTest {
     @Test
     public void testSingleSubmissionChangeFromNullToDate() {
         ResultRegistryImpl impl = new ResultRegistryImpl();
-        PhonyBundleContext pbc = new PhonyBundleContext();
-        impl.activate(pbc);
+        PhonyServiceRegistration pbc = new PhonyServiceRegistration();
+        impl.activate(getPhonyBundleContext(pbc));
         Calendar c = Calendar.getInstance();
         c.add(Calendar.HOUR, 1); //future lets it be stored
         impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), null, "tag1");
@@ -142,8 +144,8 @@ public class ResultRegistryTest {
     @Test
     public void testSingleSubmissionReplaceLessCritial() {
         ResultRegistryImpl impl = new ResultRegistryImpl();
-        PhonyBundleContext pbc = new PhonyBundleContext();
-        impl.activate(pbc);
+        PhonyServiceRegistration pbc = new PhonyServiceRegistration();
+        impl.activate(getPhonyBundleContext(pbc));
         Calendar c = Calendar.getInstance();
         c.add(Calendar.HOUR, 1); //future lets it be stored
         impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c, "tag1");
@@ -162,8 +164,8 @@ public class ResultRegistryTest {
     @Test
     public void testSingleSubmissionReplaceExpiredCriticalWithLessCritical() {
         ResultRegistryImpl impl = new ResultRegistryImpl();
-        PhonyBundleContext pbc = new PhonyBundleContext();
-        impl.activate(pbc);
+        PhonyServiceRegistration pbc = new PhonyServiceRegistration();
+        impl.activate(getPhonyBundleContext(pbc));
         Calendar c = Calendar.getInstance();
         c.add(Calendar.HOUR, 1); //future lets it be stored
         impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c, "tag1");
@@ -184,8 +186,8 @@ public class ResultRegistryTest {
     @Test
     public void testSingleSubmissionReplace() {
         ResultRegistryImpl impl = new ResultRegistryImpl();
-        PhonyBundleContext pbc = new PhonyBundleContext();
-        impl.activate(pbc);
+        PhonyServiceRegistration pbc = new PhonyServiceRegistration();
+        impl.activate(getPhonyBundleContext(pbc));
         Calendar c = Calendar.getInstance();
         c.add(Calendar.HOUR, 1); //future lets it be stored
         impl.put("identifier", new Result(Result.Status.WARN, "mywarn"), c, "tag1");
@@ -205,8 +207,8 @@ public class ResultRegistryTest {
     @Test
     public void testSingleSubmissionReplaceCalendar() {
         ResultRegistryImpl impl = new ResultRegistryImpl();
-        PhonyBundleContext pbc = new PhonyBundleContext();
-        impl.activate(pbc);
+        PhonyServiceRegistration pbc = new PhonyServiceRegistration();
+        impl.activate(getPhonyBundleContext(pbc));
         Calendar c1 = Calendar.getInstance();
         c1.add(Calendar.HOUR, 1); //future lets it be stored
         impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c1, "tag1");
@@ -228,8 +230,8 @@ public class ResultRegistryTest {
     @Test
     public void testSingleSubmissionAdd() {
         ResultRegistryImpl impl = new ResultRegistryImpl();
-        PhonyBundleContext pbc = new PhonyBundleContext();
-        impl.activate(pbc);
+        PhonyServiceRegistration pbc = new PhonyServiceRegistration();
+        impl.activate(getPhonyBundleContext(pbc));
         Calendar c1 = Calendar.getInstance();
         c1.add(Calendar.HOUR, 1); //future lets it be stored
         impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c1, "tag1");
@@ -250,8 +252,9 @@ public class ResultRegistryTest {
     @Test
     public void testSingleSubmissionRemove() {
         ResultRegistryImpl impl = new ResultRegistryImpl();
-        PhonyBundleContext pbc = new PhonyBundleContext();
-        impl.activate(pbc);
+        PhonyServiceRegistration pbc = new PhonyServiceRegistration();
+        impl.activate(getPhonyBundleContext(pbc));
+
         Calendar c = Calendar.getInstance();
         c.add(Calendar.HOUR, 1); //future lets it be stored
         impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c, "tag1");
@@ -304,18 +307,30 @@ public class ResultRegistryTest {
         assertTrue(value + " contains " + expected, !value.contains(expected));
     }
     
-    private class PhonyServiceRegistration<S> implements ServiceRegistration<S> {
+    @SuppressWarnings("rawtypes")
+    private class PhonyServiceRegistration implements ServiceRegistration {
         @SuppressWarnings("rawtypes")
         Dictionary properties;
 
+        public String[] getTags() {
+            if(properties == null) {
+                return new String[0];
+            }
+            String[] rv = (String[]) properties.get(HealthCheck.TAGS);
+            if(rv == null) {
+                return new String[0];
+            }
+            return rv;
+        }
+        
         @Override
-        public ServiceReference<S> getReference() {
+        public ServiceReference getReference() {
             // TODO Auto-generated method stub
             return null;
         }
 
         @Override
-        public void setProperties(Dictionary<String, ?> properties) {
+        public void setProperties(Dictionary properties) {
             this.properties = properties;
         }
 
@@ -326,185 +341,10 @@ public class ResultRegistryTest {
         
     }
     
-    private class PhonyBundleContext implements BundleContext {
-        @SuppressWarnings("rawtypes")
-        PhonyServiceRegistration psr = new PhonyServiceRegistration();
-        
-        public String[] getTags() {
-            if(psr.properties == null) {
-                return new String[0];
-            }
-            String[] rv = (String[])psr.properties.get(HealthCheck.TAGS);
-            if(rv == null) {
-                return new String[0];
-            }
-            return rv;
-        }
-        
-        @Override
-        public <S> ServiceRegistration<S> registerService(Class<S> clazz,
-                S service, Dictionary<String, ?> properties) {
-            return psr;
-        }
-
-        @Override
-        public String getProperty(String key) {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public Bundle getBundle() {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public Bundle installBundle(String location, InputStream input)
-                throws BundleException {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public Bundle installBundle(String location) throws BundleException {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public Bundle getBundle(long id) {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public Bundle[] getBundles() {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public void addServiceListener(ServiceListener listener, String filter)
-                throws InvalidSyntaxException {
-            // TODO Auto-generated method stub
-            
-        }
-
-        @Override
-        public void addServiceListener(ServiceListener listener) {
-            // TODO Auto-generated method stub
-            
-        }
-
-        @Override
-        public void removeServiceListener(ServiceListener listener) {
-            // TODO Auto-generated method stub
-            
-        }
-
-        @Override
-        public void addBundleListener(BundleListener listener) {
-            // TODO Auto-generated method stub
-            
-        }
-
-        @Override
-        public void removeBundleListener(BundleListener listener) {
-            // TODO Auto-generated method stub
-            
-        }
-
-        @Override
-        public void addFrameworkListener(FrameworkListener listener) {
-            // TODO Auto-generated method stub
-            
-        }
-
-        @Override
-        public void removeFrameworkListener(FrameworkListener listener) {
-            // TODO Auto-generated method stub
-            
-        }
-
-        @Override
-        public ServiceRegistration<?> registerService(String[] clazzes,
-                Object service, Dictionary<String, ?> properties) {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public ServiceRegistration<?> registerService(String clazz,
-                Object service, Dictionary<String, ?> properties) {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public ServiceReference<?>[] getServiceReferences(String clazz,
-                String filter) throws InvalidSyntaxException {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public ServiceReference<?>[] getAllServiceReferences(String clazz,
-                String filter) throws InvalidSyntaxException {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public ServiceReference<?> getServiceReference(String clazz) {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public <S> ServiceReference<S> getServiceReference(Class<S> clazz) {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public <S> Collection<ServiceReference<S>> getServiceReferences(
-                Class<S> clazz, String filter) throws InvalidSyntaxException {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public <S> S getService(ServiceReference<S> reference) {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public boolean ungetService(ServiceReference<?> reference) {
-            // TODO Auto-generated method stub
-            return false;
-        }
-
-        @Override
-        public File getDataFile(String filename) {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public Filter createFilter(String filter)
-                throws InvalidSyntaxException {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public Bundle getBundle(String location) {
-            // TODO Auto-generated method stub
-            return null;
-        }
-        
+    BundleContext getPhonyBundleContext(PhonyServiceRegistration psr) {
+        BundleContext phony = Mockito.mock(BundleContext.class);
+        Mockito.when(phony.registerService((Class<HealthCheck>)Mockito.any(Class.class), Mockito.any(ResultRegistryImpl.class), (Dictionary)Mockito.any())).thenReturn(psr);
+        return phony;
     }
-    
+       
 }

--- a/bundles/extensions/healthcheck/core/src/test/java/org/apache/sling/hc/core/impl/ResultRegistryTest.java
+++ b/bundles/extensions/healthcheck/core/src/test/java/org/apache/sling/hc/core/impl/ResultRegistryTest.java
@@ -21,18 +21,35 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
+import java.io.InputStream;
 import java.util.Calendar;
+import java.util.Collection;
+import java.util.Dictionary;
 
+import org.apache.sling.hc.api.HealthCheck;
 import org.apache.sling.hc.api.Result;
 import org.junit.Test;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.BundleListener;
+import org.osgi.framework.Filter;
+import org.osgi.framework.FrameworkListener;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceListener;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.ServiceRegistration;
 
 public class ResultRegistryTest {
 
     
+    
+    
     @Test
     public void testSingleSubmissionNoExpire() {
         ResultRegistryImpl impl = new ResultRegistryImpl();
-        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), null);
+        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), null, "tag1");
         Result rv = impl.execute();
         assertEquals(Result.Status.CRITICAL, rv.getStatus());
         assertContains("identifier", rv.toString());
@@ -42,128 +59,160 @@ public class ResultRegistryTest {
     @Test
     public void testSingleSubmissionExpireInFuture() {
         ResultRegistryImpl impl = new ResultRegistryImpl();
+        PhonyBundleContext pbc = new PhonyBundleContext();
+        impl.activate(pbc);
         Calendar c = Calendar.getInstance();
         c.add(Calendar.HOUR, 1);
-        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c);
+        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical", null), c, "tag1");
         Result rv = impl.execute();
         assertEquals(Result.Status.CRITICAL, rv.getStatus());
         assertContains("identifier", rv.toString());
         assertContains("mycritical", rv.toString());
+        assertContains("tag1", pbc.getTags());
     }
 
     @Test
     public void testSingleSubmissionExpireInPast() {
         ResultRegistryImpl impl = new ResultRegistryImpl();
+        PhonyBundleContext pbc = new PhonyBundleContext();
+        impl.activate(pbc);
         Calendar c = Calendar.getInstance();
         c.add(Calendar.HOUR, 1); //future lets it be stored
-        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c);
+        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c, "tag1");
         c.add(Calendar.HOUR, -2); //make the calendar reference become expired.
         Result rv = impl.execute();
         assertEquals(Result.Status.OK, rv.getStatus());
+        assertNotContains("tag1", pbc.getTags());
     }
 
     @Test
     public void testSingleSubmissionChangeWithExpired() {
         ResultRegistryImpl impl = new ResultRegistryImpl();
+        PhonyBundleContext pbc = new PhonyBundleContext();
+        impl.activate(pbc);
         Calendar c = Calendar.getInstance();
         c.add(Calendar.HOUR, 1); //future lets it be stored
-        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c);
+        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c, "tag1");
         c = Calendar.getInstance();
         c.add(Calendar.HOUR, -1);
-        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c); 
+        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c, "tag2"); 
         
         Result rv = impl.execute();
         assertEquals(Result.Status.CRITICAL, rv.getStatus());
+        assertContains("tag1", pbc.getTags());
+        assertNotContains("tag2", pbc.getTags());
     }
     
     
     @Test
     public void testSingleSubmissionChangeFromDateToNull() {
         ResultRegistryImpl impl = new ResultRegistryImpl();
+        PhonyBundleContext pbc = new PhonyBundleContext();
+        impl.activate(pbc);
         Calendar c = Calendar.getInstance();
         c.add(Calendar.HOUR, 1); //future lets it be stored
-        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c);
-        impl.put("identifier", new Result(Result.Status.WARN, "mycritical"), null); 
+        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c, "tag1");
+        impl.put("identifier", new Result(Result.Status.WARN, "mycritical"), null, "tag2"); 
         c.add(Calendar.HOUR, -100);
         
         Result rv = impl.execute();
         assertEquals(Result.Status.CRITICAL, rv.getStatus());
+        assertContains("tag1", pbc.getTags());
+        assertNotContains("tag2", pbc.getTags());
     }
     
     @Test
     public void testSingleSubmissionChangeFromNullToDate() {
         ResultRegistryImpl impl = new ResultRegistryImpl();
+        PhonyBundleContext pbc = new PhonyBundleContext();
+        impl.activate(pbc);
         Calendar c = Calendar.getInstance();
         c.add(Calendar.HOUR, 1); //future lets it be stored
-        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), null);
-        impl.put("identifier", new Result(Result.Status.WARN, "mywarn"), c); 
+        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), null, "tag1");
+        impl.put("identifier", new Result(Result.Status.WARN, "mywarn"), c, "tag2"); 
         c.add(Calendar.HOUR, -100);
         
         Result rv = impl.execute();
         assertEquals(Result.Status.CRITICAL, rv.getStatus());
+        assertContains("tag1", pbc.getTags());
+        assertNotContains("tag2", pbc.getTags());
     }
     
     
     @Test
     public void testSingleSubmissionReplaceLessCritial() {
         ResultRegistryImpl impl = new ResultRegistryImpl();
+        PhonyBundleContext pbc = new PhonyBundleContext();
+        impl.activate(pbc);
         Calendar c = Calendar.getInstance();
         c.add(Calendar.HOUR, 1); //future lets it be stored
-        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c);
+        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c, "tag1");
         c = Calendar.getInstance();
         c.add(Calendar.HOUR, 1); //future lets it be stored
-        impl.put("identifier", new Result(Result.Status.OK, "myok"), c); //this new one should NOT remove the current one.
+        impl.put("identifier", new Result(Result.Status.OK, "myok"), c, "tag2"); //this new one should NOT remove the current one.
         
         Result rv = impl.execute();
         assertEquals(Result.Status.CRITICAL, rv.getStatus());
         assertContains("mycritical", rv.toString());
         assertContains("identifier", rv.toString());
+        assertContains("tag1", pbc.getTags());
+        assertNotContains("tag2", pbc.getTags());
     }
     
     @Test
     public void testSingleSubmissionReplaceExpiredCriticalWithLessCritical() {
         ResultRegistryImpl impl = new ResultRegistryImpl();
+        PhonyBundleContext pbc = new PhonyBundleContext();
+        impl.activate(pbc);
         Calendar c = Calendar.getInstance();
         c.add(Calendar.HOUR, 1); //future lets it be stored
-        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c);
+        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c, "tag1");
         c.set(Calendar.HOUR, -100); //exipred critical
         c = Calendar.getInstance();
         c.add(Calendar.HOUR, 1); //future lets it be stored
-        impl.put("identifier", new Result(Result.Status.WARN, "mywarn"), c); //this new one should remove the current one.
+        impl.put("identifier", new Result(Result.Status.WARN, "mywarn"), c, "tag2"); //this new one should remove the current one.
         
         Result rv = impl.execute();
         assertEquals(Result.Status.WARN, rv.getStatus());
         assertContains("mywarn", rv.toString());
         assertContains("identifier", rv.toString());
+        assertNotContains("tag1", pbc.getTags());
+        assertContains("tag2", pbc.getTags());
     }
 
 
     @Test
     public void testSingleSubmissionReplace() {
         ResultRegistryImpl impl = new ResultRegistryImpl();
+        PhonyBundleContext pbc = new PhonyBundleContext();
+        impl.activate(pbc);
         Calendar c = Calendar.getInstance();
         c.add(Calendar.HOUR, 1); //future lets it be stored
-        impl.put("identifier", new Result(Result.Status.WARN, "mywarn"), c);
+        impl.put("identifier", new Result(Result.Status.WARN, "mywarn"), c, "tag1");
         c = Calendar.getInstance();
         c.add(Calendar.HOUR, 1); //future lets it be stored
-        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c); //this new one should remove the current one.
+        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c, "tag2"); //this new one should remove the current one.
         
         Result rv = impl.execute();
         assertEquals(Result.Status.CRITICAL, rv.getStatus());
         assertNotContains("mywarn", rv.toString());
         assertContains("identifier", rv.toString());
         assertContains("mycritical", rv.toString());
+        assertNotContains("tag1", pbc.getTags());
+        assertContains("tag2", pbc.getTags());
     }
 
     @Test
     public void testSingleSubmissionReplaceCalendar() {
         ResultRegistryImpl impl = new ResultRegistryImpl();
+        PhonyBundleContext pbc = new PhonyBundleContext();
+        impl.activate(pbc);
         Calendar c1 = Calendar.getInstance();
         c1.add(Calendar.HOUR, 1); //future lets it be stored
-        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c1);
+        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c1, "tag1");
         Calendar c2 = Calendar.getInstance();
         c2.add(Calendar.HOUR, 2); //future lets it be stored
-        impl.put("identifier", new Result(Result.Status.WARN, "mywarn"), c2); //this new one should not replace the current one, but replace it's calendar.
+        impl.put("identifier", new Result(Result.Status.WARN, "mywarn"), c2, "tag2"); //this new one should not replace the current one, but replace it's calendar.
         
         c1.add(Calendar.HOUR, -10); //making the first calendar expired.
         
@@ -172,18 +221,21 @@ public class ResultRegistryTest {
         assertNotContains("mywarn", rv.toString());
         assertContains("identifier", rv.toString());
         assertContains("mycritical", rv.toString());
+        assertContains("tag1", pbc.getTags());
+        assertNotContains("tag2", pbc.getTags());
     }
-    
     
     @Test
     public void testSingleSubmissionAdd() {
         ResultRegistryImpl impl = new ResultRegistryImpl();
+        PhonyBundleContext pbc = new PhonyBundleContext();
+        impl.activate(pbc);
         Calendar c1 = Calendar.getInstance();
         c1.add(Calendar.HOUR, 1); //future lets it be stored
-        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c1);
+        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c1, "tag1");
         Calendar c2 = Calendar.getInstance();
         c2.add(Calendar.HOUR, 1); //future lets it be stored
-        impl.put("newidentifier", new Result(Result.Status.OK, "myok"), c2); //this new one should add
+        impl.put("newidentifier", new Result(Result.Status.OK, "myok"), c2, "tag2"); //this new one should add
         
         Result rv = impl.execute();
         assertContains("identifier", rv.toString());
@@ -191,18 +243,23 @@ public class ResultRegistryTest {
         assertContains("mycritical", rv.toString());
         assertContains("myok", rv.toString());
         assertEquals(Result.Status.CRITICAL, rv.getStatus());
+        assertContains("tag1", pbc.getTags());
+        assertContains("tag2", pbc.getTags());
     }
 
     @Test
     public void testSingleSubmissionRemove() {
         ResultRegistryImpl impl = new ResultRegistryImpl();
+        PhonyBundleContext pbc = new PhonyBundleContext();
+        impl.activate(pbc);
         Calendar c = Calendar.getInstance();
         c.add(Calendar.HOUR, 1); //future lets it be stored
-        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c);
+        impl.put("identifier", new Result(Result.Status.CRITICAL, "mycritical"), c, "tag1");
         impl.remove("identifier");
         
         Result rv = impl.execute();
         assertEquals(Result.Status.OK, rv.getStatus());
+        assertNotContains("tag1", pbc.getTags());
     }
     
     void assertContains(String expected, String value) {
@@ -210,9 +267,244 @@ public class ResultRegistryTest {
         assertNotNull(value);
         assertTrue(value + " does not contain " + expected, value.contains(expected));
     }
+
+    void assertContains(String expected, String[] values) {
+        boolean found = false;
+        StringBuilder sb = new StringBuilder();
+        for(String value : values) {
+            if(expected.equals(value)) {
+                found = true;
+                break;
+            }
+            else {
+                sb.append(value + ",");
+            }
+        }
+        assertTrue("Unable to find " + expected + " in " + sb.toString(), found);
+    }
+    
+    void assertNotContains(String expected, String[] values) {
+        boolean found = false;
+        StringBuilder sb = new StringBuilder();
+        for(String value : values) {
+            if(expected.equals(value)) {
+                found = true;
+            }
+            else {
+                sb.append(value + ",");
+            }
+        }
+        assertTrue("Found " + expected + " in " + sb.toString(), !found);
+    }
+
+    
     void assertNotContains(String expected, String value) {
         assertNotNull(expected);
         assertNotNull(value);
         assertTrue(value + " contains " + expected, !value.contains(expected));
     }
+    
+    private class PhonyServiceRegistration<S> implements ServiceRegistration<S> {
+        @SuppressWarnings("rawtypes")
+        Dictionary properties;
+
+        @Override
+        public ServiceReference<S> getReference() {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public void setProperties(Dictionary<String, ?> properties) {
+            this.properties = properties;
+        }
+
+        @Override
+        public void unregister() {
+            // TODO Auto-generated method stub
+        }
+        
+    }
+    
+    private class PhonyBundleContext implements BundleContext {
+        @SuppressWarnings("rawtypes")
+        PhonyServiceRegistration psr = new PhonyServiceRegistration();
+        
+        public String[] getTags() {
+            if(psr.properties == null) {
+                return new String[0];
+            }
+            String[] rv = (String[])psr.properties.get(HealthCheck.TAGS);
+            if(rv == null) {
+                return new String[0];
+            }
+            return rv;
+        }
+        
+        @Override
+        public <S> ServiceRegistration<S> registerService(Class<S> clazz,
+                S service, Dictionary<String, ?> properties) {
+            return psr;
+        }
+
+        @Override
+        public String getProperty(String key) {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public Bundle getBundle() {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public Bundle installBundle(String location, InputStream input)
+                throws BundleException {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public Bundle installBundle(String location) throws BundleException {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public Bundle getBundle(long id) {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public Bundle[] getBundles() {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public void addServiceListener(ServiceListener listener, String filter)
+                throws InvalidSyntaxException {
+            // TODO Auto-generated method stub
+            
+        }
+
+        @Override
+        public void addServiceListener(ServiceListener listener) {
+            // TODO Auto-generated method stub
+            
+        }
+
+        @Override
+        public void removeServiceListener(ServiceListener listener) {
+            // TODO Auto-generated method stub
+            
+        }
+
+        @Override
+        public void addBundleListener(BundleListener listener) {
+            // TODO Auto-generated method stub
+            
+        }
+
+        @Override
+        public void removeBundleListener(BundleListener listener) {
+            // TODO Auto-generated method stub
+            
+        }
+
+        @Override
+        public void addFrameworkListener(FrameworkListener listener) {
+            // TODO Auto-generated method stub
+            
+        }
+
+        @Override
+        public void removeFrameworkListener(FrameworkListener listener) {
+            // TODO Auto-generated method stub
+            
+        }
+
+        @Override
+        public ServiceRegistration<?> registerService(String[] clazzes,
+                Object service, Dictionary<String, ?> properties) {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public ServiceRegistration<?> registerService(String clazz,
+                Object service, Dictionary<String, ?> properties) {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public ServiceReference<?>[] getServiceReferences(String clazz,
+                String filter) throws InvalidSyntaxException {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public ServiceReference<?>[] getAllServiceReferences(String clazz,
+                String filter) throws InvalidSyntaxException {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public ServiceReference<?> getServiceReference(String clazz) {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public <S> ServiceReference<S> getServiceReference(Class<S> clazz) {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public <S> Collection<ServiceReference<S>> getServiceReferences(
+                Class<S> clazz, String filter) throws InvalidSyntaxException {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public <S> S getService(ServiceReference<S> reference) {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public boolean ungetService(ServiceReference<?> reference) {
+            // TODO Auto-generated method stub
+            return false;
+        }
+
+        @Override
+        public File getDataFile(String filename) {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public Filter createFilter(String filter)
+                throws InvalidSyntaxException {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public Bundle getBundle(String location) {
+            // TODO Auto-generated method stub
+            return null;
+        }
+        
+    }
+    
 }


### PR DESCRIPTION
I want to provide a Registry service that can be leveraged to provide health check results.
These results can be for a period of time through an expiration, until the JVM is restarted, or added and later removed.
This can be useful when code observes a specific (possibly bad) state, and wants to alert through the health check API that this state has taken place.
Some examples: 
An event pool has filled, and some events will be thrown away.
This is a failure case that requires a restart of the instance.
It would be appropriate to trigger a permanent failure.
A quota has been tripped. This quota may immediately recover, but it is sensible to alert for 30 minutes that the quota has been tripped.
If you expect the failure will clear itself within a certain window, setting the expiration to that window can be ideal.