### PR TITLE
SLING-6623 allow async execution of pipes 

### DIFF
--- a/contrib/extensions/sling-pipes/pom.xml
+++ b/contrib/extensions/sling-pipes/pom.xml
@@ -30,7 +30,7 @@
 
   <artifactId>org.apache.sling.pipes</artifactId>
   <packaging>bundle</packaging>
-  <version>0.0.11-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
 
   <name>Apache Sling Pipes</name>
   <description>bulk content changes tool</description>
@@ -136,6 +136,11 @@
       <artifactId>org.apache.sling.commons.json</artifactId>
       <version>2.0.6</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.event.api</artifactId>
+      <version>1.0.0</version>
     </dependency>
     <!-- testing -->
     <dependency>

--- a/contrib/extensions/sling-pipes/src/main/java/org/apache/sling/pipes/BasePipe.java
+++ b/contrib/extensions/sling-pipes/src/main/java/org/apache/sling/pipes/BasePipe.java
@@ -37,6 +37,11 @@ public class BasePipe implements Pipe {
 
     public static final String RESOURCE_TYPE = "slingPipes/base";
     public static final String DRYRUN_KEY = "dryRun";
+    public static final String READ_ONLY = "readOnly";
+    public static final String PN_STATUS = "status";
+    public static final String PN_STATUS_MODIFIED = "statusModified";
+    public static final String STATUS_STARTED = "started";
+    public static final String STATUS_FINISHED = "finished";
     protected static final String DRYRUN_EXPR = "${" + DRYRUN_KEY + "}";
 
     protected ResourceResolver resolver;
@@ -61,6 +66,11 @@ public class BasePipe implements Pipe {
     @Override
     public void setParent(ContainerPipe parent) {
         this.parent = parent;
+    }
+
+    @Override
+    public Resource getResource() {
+        return resource;
     }
 
     protected Plumber plumber;

--- a/contrib/extensions/sling-pipes/src/main/java/org/apache/sling/pipes/OutputWriter.java
+++ b/contrib/extensions/sling-pipes/src/main/java/org/apache/sling/pipes/OutputWriter.java
@@ -26,41 +26,83 @@ import java.io.IOException;
 /**
  * defines how pipe's output get written to a servlet response
  */
-public interface OutputWriter {
+public abstract class OutputWriter {
 
-    String KEY_SIZE = "size";
+    public static final String KEY_SIZE = "size";
 
-    String KEY_ITEMS = "items";
+    public static final String KEY_ITEMS = "items";
+
+    public static final String PARAM_SIZE = KEY_SIZE;
+
+    public static final int NB_MAX = 10;
+
+    protected int size;
+
+    protected int max = NB_MAX;
+
+    protected Pipe pipe;
 
     /**
      *
      * @param request current request
      * @return true if this writer handles that request
      */
-    boolean handleRequest(SlingHttpServletRequest request);
+    public abstract boolean handleRequest(SlingHttpServletRequest request);
 
     /**
      * Init the writer, writes beginning of the output
      * @param request request from which writer will output
      * @param response response on which writer will output
-     * @param pipe pipe whose output will be written
      * @throws IOException error handling streams
      * @throws JSONException in case invalid json is written
      */
-    void init(SlingHttpServletRequest request, SlingHttpServletResponse response, Pipe pipe) throws IOException, JSONException;
+    public void init(SlingHttpServletRequest request, SlingHttpServletResponse response) throws IOException, JSONException{
+        max = request.getParameter(PARAM_SIZE) != null ? Integer.parseInt(request.getParameter(PARAM_SIZE)) : NB_MAX;
+        if (max < 0) {
+            max = Integer.MAX_VALUE;
+        }
+        initInternal(request, response);
+    }
+
+    /**
+     * Init the writer, writes beginning of the output
+     * @param request request from which writer will output
+     * @param response response on which writer will output
+     * @throws IOException error handling streams
+     * @throws JSONException in case invalid json is written
+     */
+    protected abstract void initInternal(SlingHttpServletRequest request, SlingHttpServletResponse response) throws IOException, JSONException;
 
     /**
      * Write a given resource
      * @param resource resource that will be written
      * @throws JSONException in case write fails
      */
-    void writeItem(Resource resource) throws JSONException;
+    public void write(Resource resource) throws JSONException{
+        if (size++ < max) {
+            writeItem(resource);
+        }
+    }
+
+    /**
+     * Write a given resource
+     * @param resource resource that will be written
+     * @throws JSONException in case write fails
+     */
+    protected abstract void writeItem(Resource resource) throws JSONException;
 
     /**
      * writes the end of the output
-     * @param size size of the overall result
      * @throws JSONException in case invalid json is written
      */
 
-    void ends(int size) throws JSONException;
+    public abstract void ends() throws JSONException;
+
+    /**
+     *
+     * @param pipe
+     */
+    public void setPipe(Pipe pipe) {
+        this.pipe = pipe;
+    }
 }

--- a/contrib/extensions/sling-pipes/src/main/java/org/apache/sling/pipes/Pipe.java
+++ b/contrib/extensions/sling-pipes/src/main/java/org/apache/sling/pipes/Pipe.java
@@ -89,6 +89,13 @@ public interface Pipe {
      */
     Resource getInput();
 
+
+    /**
+     * get the pipe configuration resource
+     * @return
+     */
+    Resource getResource();
+
     /**
      * returns the binding output used in container pipe's expression
      * @return object, either value map or something else, that will be used in nashorn for computing expressions

--- a/contrib/extensions/sling-pipes/src/main/java/org/apache/sling/pipes/Plumber.java
+++ b/contrib/extensions/sling-pipes/src/main/java/org/apache/sling/pipes/Plumber.java
@@ -19,6 +19,7 @@ package org.apache.sling.pipes;
 import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.event.jobs.Job;
 
 import java.util.Map;
 import java.util.Set;
@@ -38,36 +39,37 @@ public interface Plumber {
     Pipe getPipe(Resource resource);
 
     /**
+     * executes in a background thread
+     * @param resolver
+     * @param path
+     * @param bindings
+     * @return Job if registered, null otherwise
+     */
+    Job executeAsync(ResourceResolver resolver, String path, Map bindings);
+
+    /**
      * Executes a pipe at a certain path
      * @param resolver resource resolver with which pipe will be executed
      * @param path path of a valid pipe configuration
      * @param bindings bindings to add to the execution of the pipe, can be null
+     * @param writer output of the pipe
      * @param save in case that pipe writes anything, wether the plumber should save changes or not
      * @throws Exception in case execution fails
      * @return set of paths of output resources
      */
-    Set<String> execute(ResourceResolver resolver, String path, Map bindings, boolean save) throws Exception;
+    Set<String> execute(ResourceResolver resolver, String path, Map bindings, OutputWriter writer, boolean save) throws Exception;
 
     /**
      * Executes a given pipe
      * @param resolver resource resolver with which pipe will be executed
      * @param pipe pipe to execute
      * @param bindings bindings to add to the execution of the pipe, can be null
+     * @param writer output of the pipe
      * @param save in case that pipe writes anything, wether the plumber should save changes or not
      * @throws Exception in case execution fails
      * @return set of paths of output resources
      */
-    Set<String> execute(ResourceResolver resolver, Pipe pipe, Map bindings, boolean save) throws Exception;
-
-    /**
-     * Persist some pipe changes, and eventually distribute changes
-     * @param resolver resolver with which changes will be persisted
-     * @param pipe pipe from which the change occurred
-     * @param paths set of changed paths
-     * @throws PersistenceException in case persisting fails
-     */
-
-    void persist(ResourceResolver resolver, Pipe pipe, Set<String> paths) throws PersistenceException;
+    Set<String> execute(ResourceResolver resolver, Pipe pipe, Map bindings, OutputWriter writer, boolean save) throws Exception;
 
     /**
      * Registers
@@ -76,5 +78,17 @@ public interface Plumber {
      */
     void registerPipe(String type, Class<? extends BasePipe> pipeClass);
 
+    /**
+     * status of the pipe
+     * @param pipeResource resource corresponding to the pipe
+     * @return
+     */
+    String getStatus(Resource pipeResource);
 
+    /**
+     * returns true if the pipe is considered to be running
+     * @param pipeResource resource corresponding to the pipe
+     * @return
+     */
+    boolean isRunning(Resource pipeResource);
 }

--- a/contrib/extensions/sling-pipes/src/main/java/org/apache/sling/pipes/internal/NopWriter.java
+++ b/contrib/extensions/sling-pipes/src/main/java/org/apache/sling/pipes/internal/NopWriter.java
@@ -16,47 +16,32 @@
  */
 package org.apache.sling.pipes.internal;
 
-import java.io.IOException;
-
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.commons.json.JSONException;
-import org.apache.sling.commons.json.io.JSONWriter;
 import org.apache.sling.pipes.OutputWriter;
-import org.apache.sling.pipes.Pipe;
 
-/**
- * default output writer with size and output resources' path
- */
-public class DefaultOutputWriter extends OutputWriter {
+import java.io.IOException;
 
-    protected JSONWriter writer;
-
+public class NopWriter extends OutputWriter {
     @Override
     public boolean handleRequest(SlingHttpServletRequest request) {
-        return true;
+        return false;
     }
 
     @Override
     protected void initInternal(SlingHttpServletRequest request, SlingHttpServletResponse response) throws IOException, JSONException {
-        response.setCharacterEncoding("utf-8");
-        response.setContentType("application/json");
-        writer = new JSONWriter(response.getWriter());
-        writer.object();
-        writer.key(KEY_ITEMS);
-        writer.array();
+        //nop
     }
 
     @Override
-    public void writeItem(Resource resource) throws JSONException {
-        writer.value(resource.getPath());
+    protected void writeItem(Resource resource) throws JSONException {
+        //nop
     }
 
     @Override
     public void ends() throws JSONException {
-        writer.endArray();
-        writer.key(KEY_SIZE).value(size);
-        writer.endObject();
+        //nop
     }
 }

--- a/contrib/extensions/sling-pipes/src/main/java/org/apache/sling/pipes/package-info.java
+++ b/contrib/extensions/sling-pipes/src/main/java/org/apache/sling/pipes/package-info.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@Version("0.0.10")
+@Version("1.0.0")
 package org.apache.sling.pipes;
 
 import org.osgi.annotation.versioning.Version;

--- a/contrib/extensions/sling-pipes/src/test/java/org/apache/sling/pipes/AbstractPipeTest.java
+++ b/contrib/extensions/sling-pipes/src/test/java/org/apache/sling/pipes/AbstractPipeTest.java
@@ -30,6 +30,8 @@ import org.junit.Rule;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * this abstract class for pipes implements a plumber with all registered pipes, plus some test ones, and give some paths,
@@ -53,7 +55,11 @@ public class AbstractPipeTest {
     @Before
     public void setup(){
         PlumberImpl plumberImpl = new PlumberImpl();
-        plumberImpl.activate();
+        PlumberImpl.Configuration configuration = mock(PlumberImpl.Configuration.class);
+        when(configuration.authorizedUsers()).thenReturn(new String[]{});
+        when(configuration.serviceUser()).thenReturn(null);
+        when(configuration.bufferSize()).thenReturn(PlumberImpl.DEFAULT_BUFFER_SIZE);
+        plumberImpl.activate(configuration);
         plumberImpl.registerPipe("slingPipes/dummyNull", DummyNull.class);
         plumberImpl.registerPipe("slingPipes/dummySearch", DummySearch.class);
         plumber = plumberImpl;

--- a/contrib/extensions/sling-pipes/src/test/java/org/apache/sling/pipes/internal/PlumberServletTest.java
+++ b/contrib/extensions/sling-pipes/src/test/java/org/apache/sling/pipes/internal/PlumberServletTest.java
@@ -205,7 +205,7 @@ public class PlumberServletTest extends AbstractPipeTest {
         when(request.getParameter(PlumberServlet.PARAM_BINDINGS)).thenReturn(bindings);
         when(request.getParameter(CustomWriter.PARAM_WRITER)).thenReturn(writer);
         when(request.getParameter(BasePipe.DRYRUN_KEY)).thenReturn(dryRun);
-        when(request.getParameter(PlumberServlet.PARAM_SIZE)).thenReturn(size);
+        when(request.getParameter(OutputWriter.PARAM_SIZE)).thenReturn(size);
         return request;
     }
 


### PR DESCRIPTION
- moved execution code to a central place, under plumber implementation,
- added status, and bufferization of the commits (async execution means potentially long executions),
- added job registering & processing capabilities for plumber, based on a configurable service user (will update documentation accordingly)