### PR TITLE
docs: remove apache sling slogan since it's kinda project-racism

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,8 +1,6 @@
 Apache Sling
 ============
 
-Bringing Back the Fun!
-
 Apache Sling is a web framework that uses a Java
 Content Repository, such as Apache Jackrabbit, to store and manage content.
 


### PR DESCRIPTION
I was driving in my car on way to work. Thursday morning 6:43. Somehow, I thought aboug the Apache Sling slogan "Bringing Back the Fun!". In such a solitude moment when the streets are empty, one finds out that if Apache Sling is "Bringing Back the Fun" it implicates that other projects were or are or will be destroying the fund. Since you do not know in what kind and manner other projets go about their philosophy it's unfair from you on them and an allegation to judge their projects. So the slogan turns out to be kinda racism on other projects. This pull request removes it from the readme. :peach: 