### PR TITLE
Update old snapshot deps to current releases and snapshots

### DIFF
--- a/bundles/extensions/discovery/impl/pom.xml
+++ b/bundles/extensions/discovery/impl/pom.xml
@@ -153,7 +153,7 @@
 		<dependency>
 			<groupId>org.apache.sling</groupId>
 			<artifactId>org.apache.sling.discovery.commons</artifactId>
-			<version>1.0.21-SNAPSHOT</version>
+			<version>1.0.20</version>
             <scope>provided</scope>
 		</dependency>
         <!-- besides including discovery.commons' normal jar above, 
@@ -162,14 +162,14 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.discovery.commons</artifactId>
-            <version>1.0.21-SNAPSHOT</version>
+            <version>1.0.20</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
 		<dependency>
 			<groupId>org.apache.sling</groupId>
 			<artifactId>org.apache.sling.discovery.base</artifactId>
-			<version>2.0.1-SNAPSHOT</version>
+			<version>2.0.4</version>
             <scope>provided</scope>
 		</dependency>
         <!-- besides including discovery.base' normal jar above, 
@@ -178,7 +178,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.discovery.base</artifactId>
-            <version>2.0.1-SNAPSHOT</version>
+            <version>2.0.4</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>


### PR DESCRIPTION
Dependencies point to old snapshots that are not available anymore.
Updated to release where possible and to newest snapshot where no release was available.