### PR TITLE
SLING-7185 Added support for ISO8601 parsing

### DIFF
--- a/bundles/jcr/contentparser/src/main/java/org/apache/sling/jcr/contentparser/impl/ParserHelper.java
+++ b/bundles/jcr/contentparser/src/main/java/org/apache/sling/jcr/contentparser/impl/ParserHelper.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import javax.json.JsonObject;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.jackrabbit.util.ISO8601;
 import org.apache.sling.jcr.contentparser.ParseException;
 import org.apache.sling.jcr.contentparser.ParserOptions;
 
@@ -67,17 +68,20 @@ class ParserHelper {
 
     public Calendar tryParseCalendar(String value) {
         if (options.isDetectCalendarValues() && !StringUtils.isBlank(value)) {
-            synchronized (calendarFormat) {
+            Calendar calendar = ISO8601.parse(value);
+            if (calendar == null) {
+            	calendar = Calendar.getInstance();
                 try {
-                    Date date = calendarFormat.parse(value);
-                    Calendar calendar = Calendar.getInstance();
-                    calendar.setTime(date);
-                    return calendar;
-                }
-                catch (java.text.ParseException ex) {
+                    synchronized (calendarFormat) {
+                        Date date = calendarFormat.parse(value);
+                        calendar.setTime(date);
+                     }
+                     return calendar;
+                } catch (java.text.ParseException ex2) {
                     // ignore
                 }
             }
+            return calendar;
         }
         return null;
     }

--- a/bundles/jcr/contentparser/src/test/java/org/apache/sling/jcr/contentparser/impl/JsonContentParserTest.java
+++ b/bundles/jcr/contentparser/src/test/java/org/apache/sling/jcr/contentparser/impl/JsonContentParserTest.java
@@ -107,6 +107,28 @@ public class JsonContentParserTest {
         assertEquals(11, calendar.get(Calendar.MINUTE));
         assertEquals(24, calendar.get(Calendar.SECOND));
     }
+    
+    @Test
+    public void testIso8601Calendar() throws Exception {
+        ContentParser underTest = ContentParserFactory.create(ContentType.JSON,
+                new ParserOptions().detectCalendarValues(true));
+        ContentElement content = parse(underTest, file);
+
+        Map<String, Object> props = content.getChild("jcr:content").getProperties();
+
+        Calendar calendar = (Calendar) props.get("dateISO8601String");
+        assertNotNull(calendar);
+
+        calendar.setTimeZone(TimeZone.getTimeZone("GMT+2"));
+
+        assertEquals(2014, calendar.get(Calendar.YEAR));
+        assertEquals(4, calendar.get(Calendar.MONTH) + 1);
+        assertEquals(22, calendar.get(Calendar.DAY_OF_MONTH));
+
+        assertEquals(15, calendar.get(Calendar.HOUR_OF_DAY));
+        assertEquals(11, calendar.get(Calendar.MINUTE));
+        assertEquals(24, calendar.get(Calendar.SECOND));
+    }
 
     @Test
     public void testUTF8Chars() throws Exception {


### PR DESCRIPTION
Parsing is of a relatively strict format, requiring date, time, and offset. Milliseconds to 3 decimals are required. 